### PR TITLE
Support buy orders

### DIFF
--- a/src/Order.sol
+++ b/src/Order.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.13;
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import './interfaces/IOrderBook.sol';
 
-contract SellOrder {
+contract Order {
     /// @dev Don't allow purchases from self
-    error BuyerCannotBeSeller();
+    error TakerCannotBeMaker();
 
-    /// @dev msg.sender is not the seller
-    error MustBeSeller();
+    /// @dev msg.sender is not the maker of the order
+    error MustBeMaker();
 
     /// @dev A function is run at the wrong time in the lifecycle
     error InvalidState(State expected, State received);
@@ -17,9 +17,9 @@ contract SellOrder {
     /// @dev The order is not accepting new offers
     error OrderInactive();
 
-    /// @dev Emitted when `buyer` submits and offer.
+    /// @dev Emitted when `taker` submits an offer.
     event OfferSubmitted(
-        address indexed buyer,
+        address indexed taker,
         uint32 indexed index,
         uint32 quantity,
         uint128 pricePerUnit,
@@ -27,50 +27,50 @@ contract SellOrder {
         string uri
     );
 
-    /// @dev Emitted when `buyer` withdrew and offer.
-    event OfferWithdrawn(address indexed buyer, uint32 indexed index);
+    /// @dev Emitted when `taker` withdrew an offer.
+    event OfferWithdrawn(address indexed taker, uint32 indexed index);
 
-    /// @dev Emitted when `buyer`'s offer was commited too.
-    event OfferCommitted(address indexed buyer, uint32 indexed index);
+    /// @dev Emitted when `taker`'s offer was committed too.
+    event OfferCommitted(address indexed taker, uint32 indexed index);
 
-    /// @dev Emitted when `buyer` withdrew and offer.
-    event OfferConfirmed(address indexed buyer, uint32 indexed index);
+    /// @dev Emitted when `taker` confirmed an offer was completed.
+    event OfferConfirmed(address indexed taker, uint32 indexed index);
 
-    /// @dev Emitted when `buyer` withdrew and offer.
-    event OfferEnforced(address indexed buyer, uint32 indexed index);
+    /// @dev Emitted when an offer was enforced.
+    event OfferEnforced(address indexed taker, uint32 indexed index);
 
-    /// @dev Emitted when `seller` sets sell order active or inactive.
+    /// @dev Emitted when `maker` sets the order active or inactive.
     event ActiveToggled(bool active);
 
-    /// @dev Someone requested a cancellation of the sell order. The order is
-    ///      is only "really" canceled if both sellerCanceled and buyerCanceled is
+    /// @dev Someone requested a cancellation of the order. The order is only
+    ///      "really" canceled if both makerCanceled and takerCanceled is
     ///      true.
     event OfferCanceled(
-        address indexed buyer,
+        address indexed taker,
         uint32 indexed index,
-        bool sellerCanceled,
-        bool buyerCanceled
+        bool makerCanceled,
+        bool takerCanceled
     );
 
-    /// @dev The sell order's URI changed
+    /// @dev The order's URI changed
     event OrderURIChanged(string previous, string next);
 
     /// @dev The token used for payment & staking, such as wETH, DAI, or USDC.
     IERC20 public token;
 
-    /// @dev The seller
-    address public seller;
+    /// @dev The maker of this order book entry (as in, the "market maker")
+    address public maker;
 
     /// @dev the maximum delivery time before the order can said to have failed.
     uint256 public timeout;
 
-    /// @dev the amount the seller is offering to stake per order.
+    /// @dev the amount the maker is offering to stake per order.
     uint256 public orderStake;
 
     /// @dev order book
     address public orderBook;
 
-    /// @dev the URI where metadata about this SellOrder can be found
+    /// @dev the URI where metadata about this Order can be found
     string private _uri;
 
     /// @dev if false, the order is not open for new offers.
@@ -94,12 +94,12 @@ contract SellOrder {
         string uri;
         /// @dev the block.timestamp in which acceptOffer() was called. 0 otherwise
         uint64 acceptedAt;
-        /// @dev canceled by the seller
-        bool sellerCanceled;
-        /// @dev canceled by the buyer
-        bool buyerCanceled;
-        /// @dev Allows a buyer to purchase multiple units.
-        /// The seller will need to stake quantity*stake to accept.
+        /// @dev canceled by the maker
+        bool makerCanceled;
+        /// @dev canceled by the taker
+        bool takerCanceled;
+        /// @dev Allows purchases of multiple units.
+        /// The maker and taker's required stakes will both be scaled by this value.
         uint32 quantity;
     }
 
@@ -109,8 +109,8 @@ contract SellOrder {
     ///     on behalf of a large number of users.
     ///
     ///     If, for some reason, ~2 billion open offers does not support your use case, you
-    ///     could just create another address for your buyer (shard), implement a queue,
-    ///     or we could just release a new version.
+    ///     could just create another address for your additonal takers (shard), implement a
+    ///     queue, or we could just release a new version.
     mapping(address => mapping(uint32 => Offer)) public offers;
 
     /// @dev The denominator of parts per million
@@ -118,14 +118,14 @@ contract SellOrder {
 
     /// @dev Creates a new sell order.
     constructor(
-        address seller_,
+        address maker_,
         IERC20 token_,
         uint256 orderStake_,
         string memory uri_,
         uint256 timeout_
     ) {
         orderBook = msg.sender;
-        seller = seller_;
+        maker = maker_;
         token = token_;
         orderStake = orderStake_;
         _uri = uri_;
@@ -139,34 +139,34 @@ contract SellOrder {
     }
 
     /// @dev sets the URI of the sell order, containing it's metadata
-    function setURI(string memory uri_) external virtual onlySeller {
+    function setURI(string memory uri_) external virtual onlyMaker {
         _uri = uri_;
         emit OrderURIChanged(_uri, uri_);
     }
 
     /// @dev Sets "active". If false, the order is not open for new offers.
-    function setActive(bool active_) external virtual onlySeller {
+    function setActive(bool active_) external virtual onlyMaker {
         active = active_;
         emit ActiveToggled(active);
     }
 
     /// @dev reverts if the function is not at the expected state
     modifier onlyState(
-        address buyer_,
+        address taker_,
         uint32 index,
         State expected
     ) {
-        if (offers[buyer_][index].state != expected) {
-            revert InvalidState(expected, offers[buyer_][index].state);
+        if (offers[taker_][index].state != expected) {
+            revert InvalidState(expected, offers[taker_][index].state);
         }
 
         _;
     }
 
-    /// @dev reverts if msg.sender is not the seller
-    modifier onlySeller() {
-        if (msg.sender != seller) {
-            revert MustBeSeller();
+    /// @dev reverts if msg.sender is not the maker
+    modifier onlyMaker() {
+        if (msg.sender != maker) {
+            revert MustBeMaker();
         }
 
         _;
@@ -189,8 +189,8 @@ contract SellOrder {
         uint128 stakePerUnit,
         string memory uri
     ) external virtual onlyState(msg.sender, index, State.Closed) onlyActive {
-        if (msg.sender == seller) {
-            revert BuyerCannotBeSeller();
+        if (msg.sender == maker) {
+            revert TakerCannotBeMaker();
         }
 
         Offer storage offer = offers[msg.sender][index];
@@ -217,7 +217,7 @@ contract SellOrder {
         );
     }
 
-    /// @dev allows a buyer to withdraw the offer
+    /// @dev allows a taker to withdraw a previous offer
     function withdrawOffer(uint32 index)
         external
         virtual
@@ -245,19 +245,19 @@ contract SellOrder {
         emit OfferWithdrawn(msg.sender, index);
     }
 
-    /// @dev Commits a seller to an offer
-    function commit(address buyer_, uint32 index)
+    /// @dev Commits a maker to an offer
+    function commit(address taker_, uint32 index)
         public
         virtual
-        onlyState(buyer_, index, State.Open)
-        onlySeller
+        onlyState(taker_, index, State.Open)
+        onlyMaker
     {
         // Deposit the stake required to commit to the offer
         uint256 allowance = token.allowance(msg.sender, address(this));
         require(allowance >= orderStake);
 
-        // Update the status of the buyer's offer
-        Offer storage offer = offers[buyer_][index];
+        // Update the status of the taker's offer
+        Offer storage offer = offers[taker_][index];
         offer.acceptedAt = uint64(block.timestamp);
         offer.state = State.Committed;
 
@@ -268,17 +268,17 @@ contract SellOrder {
         );
         assert(result);
 
-        emit OfferCommitted(buyer_, index);
+        emit OfferCommitted(taker_, index);
     }
 
     /// @dev Marks all provided offers as confirmed
-    function commitBatch(address[] calldata buyers, uint32[] calldata indices)
+    function commitBatch(address[] calldata takers, uint32[] calldata indices)
         external
         virtual
     {
-        require(buyers.length == indices.length);
-        for (uint256 i = 0; i < buyers.length; i++) {
-            commit(buyers[i], indices[i]);
+        require(takers.length == indices.length);
+        for (uint256 i = 0; i < takers.length; i++) {
+            commit(takers[i], indices[i]);
         }
     }
 
@@ -301,7 +301,7 @@ contract SellOrder {
             0
         );
 
-        // Return the stake to the buyer
+        // Return the taker stake back to the buyer
         bool result0 = token.transfer(
             msg.sender,
             offer.stakePerUnit * offer.quantity
@@ -313,9 +313,9 @@ contract SellOrder {
             ONE_MILLION;
         uint256 toSeller = total - toOrderBook;
 
-        // Transfer payment to the seller, along with their stake
+        // Return the maker stake back to the seller, along with the buyer's payment
         bool result1 = token.transfer(
-            seller,
+            maker,
             toSeller + (orderStake * offer.quantity)
         );
         assert(result1);
@@ -338,16 +338,16 @@ contract SellOrder {
     }
 
     /// @dev Allows anyone to enforce an offer.
-    function enforce(address buyer_, uint32 index)
+    function enforce(address taker_, uint32 index)
         public
         virtual
-        onlyState(buyer_, index, State.Committed)
+        onlyState(taker_, index, State.Committed)
     {
-        Offer memory offer = offers[buyer_][index];
+        Offer memory offer = offers[taker_][index];
         require(block.timestamp > timeout + offer.acceptedAt);
 
         // Close the offer
-        offers[buyer_][index] = Offer(
+        offers[taker_][index] = Offer(
             State.Closed,
             0,
             0,
@@ -360,74 +360,74 @@ contract SellOrder {
 
         // Transfer the payment to the seller
         bool result0 = token.transfer(
-            seller,
+            maker,
             (offer.pricePerUnit * offer.quantity)
         );
         assert(result0);
 
-        // Transfer the buyer's stake to address(dead).
+        // Transfer the taker's stake to address(dead).
         bool result1 = token.transfer(
             address(0x000000000000000000000000000000000000dEaD),
             (offer.stakePerUnit * offer.quantity)
         );
         assert(result1);
 
-        // Transfer the seller's stake to address(dead).
+        // Transfer the maker's stake to address(dead).
         bool result2 = token.transfer(
             address(0x000000000000000000000000000000000000dEaD),
             orderStake * offer.quantity
         );
         assert(result2);
 
-        emit OfferEnforced(buyer_, index);
+        emit OfferEnforced(taker_, index);
     }
 
     /// @dev Enforces all provided offers
-    function enforceBatch(address[] calldata buyers, uint32[] calldata indices)
+    function enforceBatch(address[] calldata takers, uint32[] calldata indices)
         external
         virtual
     {
-        require(buyers.length == indices.length);
-        for (uint256 i = 0; i < buyers.length; i++) {
-            enforce(buyers[i], indices[i]);
+        require(takers.length == indices.length);
+        for (uint256 i = 0; i < takers.length; i++) {
+            enforce(takers[i], indices[i]);
         }
     }
 
-    /// @dev Allows either the buyer or the seller to cancel the offer.
+    /// @dev Allows either the taker or the maker to cancel the offer.
     ///      Only a committed offer can be canceled
-    function cancel(address buyer_, uint32 index)
+    function cancel(address taker_, uint32 index)
         public
         virtual
-        onlyState(buyer_, index, State.Committed)
+        onlyState(taker_, index, State.Committed)
     {
-        Offer storage offer = offers[buyer_][index];
-        if (msg.sender == buyer_) {
-            // The buyer is canceling their offer
-            offer.buyerCanceled = true;
+        Offer storage offer = offers[taker_][index];
+        if (msg.sender == taker_) {
+            // The taker is canceling their offer
+            offer.takerCanceled = true;
         } else {
-            // The seller is canceling their offer
-            if (msg.sender != seller) {
-                revert MustBeSeller();
+            // The maker is canceling their offer
+            if (msg.sender != maker) {
+                revert MustBeMaker();
             }
-            offer.sellerCanceled = true;
+            offer.makerCanceled = true;
         }
 
-        // If both parties canceled, then return the stakes, and the payment to the buyer
+        // If both parties canceled, then return the stakes, and the payment to the taker
         // and set the offer to closed
-        if (offer.sellerCanceled && offer.buyerCanceled) {
-            // Transfer the stake to the buyer along with their payment
+        if (offer.makerCanceled && offer.takerCanceled) {
+            // Transfer the taker stake back to the buyer along with their payment
             bool result0 = token.transfer(
-                buyer_,
+                taker_,
                 (offer.stakePerUnit + offer.pricePerUnit) * offer.quantity
             );
             assert(result0);
 
-            // Transfer the stake to the seller
-            bool result1 = token.transfer(seller, orderStake * offer.quantity);
+            // Transfer the maker stake back to the seller
+            bool result1 = token.transfer(maker, orderStake * offer.quantity);
             assert(result1);
 
             // Null out the offer
-            offers[buyer_][index] = Offer(
+            offers[taker_][index] = Offer(
                 State.Closed,
                 0,
                 0,
@@ -440,21 +440,21 @@ contract SellOrder {
         }
 
         emit OfferCanceled(
-            buyer_,
+            taker_,
             index,
-            offer.sellerCanceled,
-            offer.buyerCanceled
+            offer.makerCanceled,
+            offer.takerCanceled
         );
     }
 
     /// @dev Cancels all provided offers
-    function cancelBatch(address[] calldata buyers, uint32[] calldata indices)
+    function cancelBatch(address[] calldata takers, uint32[] calldata indices)
         external
         virtual
     {
-        require(buyers.length == indices.length);
-        for (uint256 i = 0; i < buyers.length; i++) {
-            cancel(buyers[i], indices[i]);
+        require(takers.length == indices.length);
+        for (uint256 i = 0; i < takers.length; i++) {
+            cancel(takers[i], indices[i]);
         }
     }
 }

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import './SellOrder.sol';
+import './Order.sol';
 import './interfaces/IOrderBook.sol';
 
 /// @dev A factory for creating orders. The Graph should index this contract.
 contract OrderBook is IOrderBook {
-    /// @dev all the sell orders available in the order book
-    mapping(address => bool) public sellOrders;
+    /// @dev all the orders available in the order book
+    mapping(address => bool) public orders;
 
     /// @dev the fee rate in parts per million
     uint256 public fee = 10000; // 1%
@@ -53,17 +53,17 @@ contract OrderBook is IOrderBook {
         _owner = _newOwner;
     }
 
-    /// @dev Creates a new sell order that can be easily indexed by something like theGraph.
-    function createSellOrder(
-        address seller,
+    /// @dev Creates a new order that can be easily indexed by something like theGraph.
+    function createOrder(
+        address maker,
         IERC20 token,
         uint256 stake,
         string memory uri,
         uint256 timeout
-    ) external returns (SellOrder) {
-        SellOrder sellOrder = new SellOrder(seller, token, stake, uri, timeout);
-        emit SellOrderCreated(address(sellOrder));
-        sellOrders[address(sellOrder)] = true;
-        return sellOrder;
+    ) external returns (Order) {
+        Order order = new Order(maker, token, stake, uri, timeout);
+        emit OrderCreated(address(order));
+        orders[address(order)] = true;
+        return order;
     }
 }

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -59,9 +59,16 @@ contract OrderBook is IOrderBook {
         IERC20 token,
         uint256 stake,
         string memory uri,
-        uint256 timeout
+        uint256 timeout,
+        bool isBuyOrder
     ) external returns (Order) {
-        Order order = new Order(maker, token, stake, uri, timeout);
+        Order.OrderType orderType;
+        if (isBuyOrder) {
+            orderType = Order.OrderType.BuyOrder;
+        } else {
+            orderType = Order.OrderType.SellOrder;
+        }
+        Order order = new Order(maker, token, stake, uri, timeout, orderType);
         emit OrderCreated(address(order));
         orders[address(order)] = true;
         return order;

--- a/src/interfaces/IOrderBook.sol
+++ b/src/interfaces/IOrderBook.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.13;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '../SellOrder.sol';
+import '../Order.sol';
 
 interface IOrderBook {
-    event SellOrderCreated(address indexed sellOrder);
+    event OrderCreated(address indexed order);
 
     event OwnerChanged(address previous, address next);
 
@@ -19,11 +19,11 @@ interface IOrderBook {
 
     function setOwner(address _newOwner) external;
 
-    function createSellOrder(
-        address seller,
+    function createOrder(
+        address maker,
         IERC20 token,
         uint256 stake,
         string memory uri,
         uint256 timeout
-    ) external returns (SellOrder);
+    ) external returns (Order);
 }

--- a/src/interfaces/IOrderBook.sol
+++ b/src/interfaces/IOrderBook.sol
@@ -24,6 +24,7 @@ interface IOrderBook {
         IERC20 token,
         uint256 stake,
         string memory uri,
-        uint256 timeout
+        uint256 timeout,
+        bool isBuyOrder
     ) external returns (Order);
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -31,7 +31,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         assert(address(sellOrder.token()) == address(token));
@@ -51,7 +52,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         token.transfer(buyer, 20);
@@ -101,7 +103,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         token.transfer(buyer, 20);
@@ -130,7 +133,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         // Submit an offer from buyer1
@@ -210,7 +214,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         // Submit an offer from seller
@@ -235,7 +240,8 @@ contract SellOrderTest is Test {
             token,
             50, // stake
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         // Submit an offer
@@ -282,7 +288,8 @@ contract SellOrderTest is Test {
             token,
             50,
             'ipfs://metadata',
-            100
+            100,
+            false
         );
 
         // Submit an offer from buyer1
@@ -377,7 +384,8 @@ contract CancelationTest is Test {
             token,
             50, // stake
             'ipfs://metadata',
-            100
+            100,
+            false
         );
     }
 
@@ -552,7 +560,8 @@ contract QuantityTest is Test {
             token,
             sellersStake, // stake
             'ipfs://metadata',
-            100
+            100,
+            false
         );
     }
 

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import 'forge-std/Test.sol';
 import './ERC20Mock.sol';
-import '../src/SellOrder.sol';
+import '../src/Order.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import '../src/OrderBook.sol';
 
@@ -26,7 +26,7 @@ contract SellOrderTest is Test {
 
     function testConstructor() public {
         ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             address(this),
             token,
             50,
@@ -46,7 +46,7 @@ contract SellOrderTest is Test {
         address buyer = address(0x5234567890123456754012345678901234567822);
 
         // Create a sell order
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50,
@@ -96,7 +96,7 @@ contract SellOrderTest is Test {
         address buyer = address(0x2234567890123456754012345678901234567821);
 
         // Create a sell order
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50,
@@ -125,7 +125,7 @@ contract SellOrderTest is Test {
         address buyer2 = address(0x5234567890123456754012345678901234567822);
 
         // Create a sell order
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50,
@@ -166,12 +166,12 @@ contract SellOrderTest is Test {
         sellOrder.commit(buyer2, 0);
         vm.stopPrank();
 
-        (SellOrder.State offerState1, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState1, , , , , , , ) = sellOrder.offers(
             buyer2,
             0
         );
         require(
-            offerState1 == SellOrder.State.Committed,
+            offerState1 == Order.State.Committed,
             'state is not committed'
         );
         require(
@@ -183,14 +183,14 @@ contract SellOrderTest is Test {
         vm.prank(buyer2);
         sellOrder.confirm(0);
 
-        (SellOrder.State offerState2, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState2, , , , , , , ) = sellOrder.offers(
             buyer2,
             0
         );
-        require(offerState2 == SellOrder.State.Closed, 'state is not Closed');
+        require(offerState2 == Order.State.Closed, 'state is not Closed');
 
         require(
-            token.balanceOf(sellOrder.seller()) == 60, // 60 = payment + stake
+            token.balanceOf(sellOrder.maker()) == 60, // 60 = payment + stake
             'seller did not get paid'
         );
         require(
@@ -205,7 +205,7 @@ contract SellOrderTest is Test {
         address seller = address(0x1234567890123456784012345678901234567829);
 
         // Create a sell order
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50,
@@ -230,7 +230,7 @@ contract SellOrderTest is Test {
 
         // Create a sell order
 
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50, // stake
@@ -277,7 +277,7 @@ contract SellOrderTest is Test {
         address buyer2 = address(0x5234567890123456754012345678901234567822);
 
         // Create a sell order
-        SellOrder sellOrder = book.createSellOrder(
+        Order sellOrder = book.createOrder(
             seller,
             token,
             50,
@@ -324,12 +324,12 @@ contract SellOrderTest is Test {
         sellOrder.commitBatch(buyers, offerIndices);
         vm.stopPrank();
 
-        (SellOrder.State offerState1, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState1, , , , , , , ) = sellOrder.offers(
             buyer2,
             0
         );
         require(
-            offerState1 == SellOrder.State.Committed,
+            offerState1 == Order.State.Committed,
             'state is not committed'
         );
         require(
@@ -341,14 +341,14 @@ contract SellOrderTest is Test {
         vm.prank(buyer2);
         sellOrder.confirm(0);
 
-        (SellOrder.State offerState2, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState2, , , , , , , ) = sellOrder.offers(
             buyer2,
             0
         );
-        require(offerState2 == SellOrder.State.Closed, 'state is not Closed');
+        require(offerState2 == Order.State.Closed, 'state is not Closed');
 
         require(
-            token.balanceOf(sellOrder.seller()) == 60, // 60 = payment + stake
+            token.balanceOf(sellOrder.maker()) == 60, // 60 = payment + stake
             'seller did not get paid'
         );
         require(
@@ -359,7 +359,7 @@ contract SellOrderTest is Test {
 }
 
 contract CancelationTest is Test {
-    SellOrder sellOrder;
+    Order sellOrder;
     address DAO = address(0x4234567890123456784012345678901234567821);
     address seller = address(0x1234567890123456784012345678901234567829);
     ERC20Mock token;
@@ -372,7 +372,7 @@ contract CancelationTest is Test {
         token = new ERC20Mock('wETH', 'WETH', address(this), 20000);
 
         // Create a sell order
-        sellOrder = book.createSellOrder(
+        sellOrder = book.createOrder(
             seller,
             token,
             50, // stake
@@ -424,11 +424,11 @@ contract CancelationTest is Test {
             'seller should be cleared'
         );
 
-        (SellOrder.State offerState2, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState2, , , , , , , ) = sellOrder.offers(
             buyer,
             0
         );
-        require(offerState2 == SellOrder.State.Closed, 'state is not Closed');
+        require(offerState2 == Order.State.Closed, 'state is not Closed');
     }
 
     function buyAndCommit(address buyer, uint32 index) public {
@@ -490,22 +490,22 @@ contract CancelationTest is Test {
         buyAndCommit(buyer, 0);
         buyAndCommit(buyer, 1);
 
-        (SellOrder.State offerState0, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState0, , , , , , , ) = sellOrder.offers(
             buyer,
             0
         );
-        (SellOrder.State offerState1, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState1, , , , , , , ) = sellOrder.offers(
             buyer,
             1
         );
 
         require(
-            offerState0 == SellOrder.State.Committed,
+            offerState0 == Order.State.Committed,
             'state is not Committed'
         );
 
         require(
-            offerState1 == SellOrder.State.Committed,
+            offerState1 == Order.State.Committed,
             'state is not Committed'
         );
     }
@@ -534,7 +534,7 @@ contract CancelationTest is Test {
 }
 
 contract QuantityTest is Test {
-    SellOrder sellOrder;
+    Order sellOrder;
     address DAO = address(0x4234567890123456784012345678901234567821);
     address seller = address(0x1234567890123456784012345678901234567829);
     ERC20Mock token;
@@ -547,7 +547,7 @@ contract QuantityTest is Test {
         token = new ERC20Mock('wETH', 'WETH', address(this), 20000);
 
         // Create a sell order
-        sellOrder = book.createSellOrder(
+        sellOrder = book.createOrder(
             seller,
             token,
             sellersStake, // stake
@@ -598,11 +598,11 @@ contract QuantityTest is Test {
         );
 
         // Check the state
-        (SellOrder.State offerState, , , , , , , ) = sellOrder.offers(
+        (Order.State offerState, , , , , , , ) = sellOrder.offers(
             buyer,
             index
         );
-        require(offerState == SellOrder.State.Closed, 'state is not Closed');
+        require(offerState == Order.State.Closed, 'state is not Closed');
     }
 }
 


### PR DESCRIPTION
I will add tests before merging, but wanted to share my approach here earlier since it's a large change.

My initial insight was that there are two independent roles someone can take when interacting with the RWTP contract: the buyer/seller axis, and the orderer/offerer axis. I've adopted `maker` and `taker` terminology to refer to the orderer and offerer respectively throughout the contract. The `maker` is the "market maker", or the one who submits the order. The `taker` is the one who takes an order by making an offer. That made it very easy to reuse the existing sell order code as a generalized buy or sell order. Stake transfers are specific to the maker and taker, whereas price transfers are specific to the buyer and seller. The existing `Offer` type can still accurately describe a seller's offer without any changes.

`orderType` is now an enum field on `Order` (formerly `SellOrder`). For a sell order, The maker is the seller and the taker is the buyer, and vice versa for buy orders. The payment is transfered when the buyer puts up their stake amount, so either when the offer is submitted for sell orders or when the offer is committed for buy orders.