### PR TITLE
Order contract refactor

### DIFF
--- a/src/Order.sol
+++ b/src/Order.sol
@@ -493,19 +493,16 @@ contract Order {
         );
         assert(result0);
 
-        // Transfer the buyer's stake to address(dead).
+        // Transfers to address(dead)
         bool result1 = token.transfer(
             address(0x000000000000000000000000000000000000dEaD),
-            buyerStakePerUnit(offer) * offer.quantity
+            (
+                buyerStakePerUnit(offer) // buyer's stake
+                + offer.sellerStakePerUnit // seller's stake
+                + (offer.pricePerUnit - refundPerUnit(offer)) * offer.quantity // non-refundable purchase amount
+            ) * offer.quantity
         );
         assert(result1);
-
-        // Transfer the seller's stake to address(dead).
-        bool result2 = token.transfer(
-            address(0x000000000000000000000000000000000000dEaD),
-            offer.sellerStakePerUnit * offer.quantity
-        );
-        assert(result2);
 
         emit OfferRefunded(taker_, index);
     }

--- a/src/Order.sol
+++ b/src/Order.sol
@@ -432,7 +432,6 @@ contract Order {
             ONE_MILLION;
         uint256 toSeller = total - toOrderBook;
         uint256 toBuyer = buyerStakePerUnit(offer) * offer.quantity;
-        // uint256 toBuyer = 1 * offer.quantity;
 
         // Transfer payment to the buyer
         bool result0 = token.transfer(buyer(taker_), toBuyer);

--- a/src/Order.sol
+++ b/src/Order.sol
@@ -400,16 +400,16 @@ contract Order {
             0
         );
 
-        // Transfer the payment to the seller, which is the maker of a sell order or the taker of a buy order.
-        address seller;
+        // Transfer the payment to the buyer, which is the taker of a sell order or the maker of a buy order.
+        address buyer;
         if (orderType == OrderType.SellOrder) {
-            seller = maker;
+            buyer = taker_;
         } else if (orderType == OrderType.BuyOrder) {
-            seller = taker_;
+            buyer = maker;
         }
 
         bool result0 = token.transfer(
-            seller,
+            buyer,
             (offer.pricePerUnit * offer.quantity)
         );
         assert(result0);

--- a/src/Order.sol
+++ b/src/Order.sol
@@ -427,10 +427,10 @@ contract Order {
             0
         );
 
-        uint256 total = (offer.pricePerUnit + offer.sellerStakePerUnit) * offer.quantity;
+        uint256 total = offer.pricePerUnit * offer.quantity;
         uint256 toOrderBook = (total * IOrderBook(orderBook).fee()) /
             ONE_MILLION;
-        uint256 toSeller = total - toOrderBook;
+        uint256 toSeller = total - toOrderBook + (offer.sellerStakePerUnit * offer.quantity);
         uint256 toBuyer = buyerStakePerUnit(offer) * offer.quantity;
 
         // Transfer payment to the buyer

--- a/src/Order.sol
+++ b/src/Order.sol
@@ -499,7 +499,7 @@ contract Order {
             (
                 buyerStakePerUnit(offer) // buyer's stake
                 + offer.sellerStakePerUnit // seller's stake
-                + (offer.pricePerUnit - refundPerUnit(offer)) * offer.quantity // non-refundable purchase amount
+                + offer.pricePerUnit - refundPerUnit(offer) // non-refundable purchase amount
             ) * offer.quantity
         );
         assert(result1);

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.13;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import "@openzeppelin/contracts/security/Pausable.sol";
 import './Order.sol';
 import './interfaces/IOrderBook.sol';
 
 /// @dev A factory for creating orders. The Graph should index this contract.
-contract OrderBook is IOrderBook {
+contract OrderBook is IOrderBook, Pausable {
     /// @dev all the orders available in the order book
     mapping(address => bool) public orders;
 
@@ -53,6 +54,16 @@ contract OrderBook is IOrderBook {
         _owner = _newOwner;
     }
 
+    /// @dev pauses this order book
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @dev unpauses this order book
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
     /// @dev Creates a new order that can be easily indexed by something like theGraph.
     function createOrder(
         address maker,
@@ -60,7 +71,7 @@ contract OrderBook is IOrderBook {
         string memory uri,
         uint256 timeout,
         bool isBuyOrder
-    ) external returns (Order) {
+    ) external whenNotPaused returns (Order) {
         Order.OrderType orderType;
         if (isBuyOrder) {
             orderType = Order.OrderType.BuyOrder;

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -57,7 +57,6 @@ contract OrderBook is IOrderBook {
     function createOrder(
         address maker,
         IERC20 token,
-        uint256 stake,
         string memory uri,
         uint256 timeout,
         bool isBuyOrder
@@ -68,7 +67,7 @@ contract OrderBook is IOrderBook {
         } else {
             orderType = Order.OrderType.SellOrder;
         }
-        Order order = new Order(maker, token, stake, uri, timeout, orderType);
+        Order order = new Order(maker, token, uri, timeout, orderType);
         emit OrderCreated(address(order));
         orders[address(order)] = true;
         return order;

--- a/src/interfaces/IOrderBook.sol
+++ b/src/interfaces/IOrderBook.sol
@@ -22,7 +22,6 @@ interface IOrderBook {
     function createOrder(
         address maker,
         IERC20 token,
-        uint256 stake,
         string memory uri,
         uint256 timeout,
         bool isBuyOrder

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -511,7 +511,7 @@ contract SellOrderTest is Test {
         );
         require(offerState == Order.State.Closed, 'incorrect offer state');
 
-        uint256 total = (pricePerUnit + sellerStakePerUnit) * quantity;
+        uint256 total = pricePerUnit * quantity;
         uint256 toDao = (total * IOrderBook(book).fee()) / 1000000;
 
         require(
@@ -520,7 +520,7 @@ contract SellOrderTest is Test {
         );
 
         require(
-            token.balanceOf(maker) == makerStartBalance + total - toDao,
+            token.balanceOf(maker) == makerStartBalance + total - toDao + sellerStakePerUnit * quantity,
             'incorrect transfer to seller'
         );
 

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -165,7 +165,7 @@ contract OrderTest is Test {
         submitOfferBase(order, taker1);
     }
 
-    function testFailSubmitOfferLacksToken() public {
+    function testSubmitOfferLacksToken() public {
         uint32 index = 0;
         uint128 price = 1;
         uint128 cost = 1;

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -165,7 +165,7 @@ contract OrderTest is Test {
         submitOfferBase(order, taker1);
     }
 
-    function testSubmitOfferLacksToken() public {
+    function testFailSubmitOfferLacksToken() public {
         uint32 index = 0;
         uint128 price = 1;
         uint128 cost = 1;

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -5,537 +5,15 @@ import 'forge-std/Test.sol';
 import './ERC20Mock.sol';
 import '../src/Order.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '../src/OrderBook.sol';
 
 contract SellOrderTest is Test {
-    address DAO = address(0x4234567890123456784012345678901234567821);
-    OrderBook book;
-
-    function setUp() public {
-        vm.prank(DAO);
-        book = new OrderBook();
-    }
-
-    function toSignature(
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(v, r, s);
-    }
-
-    function testConstructor() public {
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        Order sellOrder = book.createOrder(
-            address(this),
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        assert(address(sellOrder.token()) == address(token));
-    }
-
-    // Test refund function (can't be refunded before time limit, can be refunded afterwards)
-    function testRefund() public {
-        vm.warp(0); // set the time to 0
-        // Setup
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        address seller = address(0x1234567890123456784012345678901234567829);
-        address buyer = address(0x5234567890123456754012345678901234567822);
-
-        // Create a sell order
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        token.transfer(buyer, 20);
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), 10);
-        sellOrder.submitOffer(0, 1, 10, 10, 50, 'ipfs://somedata');
-        vm.stopPrank();
-        (, uint256 offer2price, uint256 offer2cost, , , , , , ) = sellOrder
-            .offers(buyer, 0);
-        require(offer2price == 10, 'offer price2 is not 10');
-        require(offer2cost == 10, 'offer cost2 is not 10');
-
-        vm.warp(30); // warp to block 30
-        // Confirm buyer's offer
-        token.transfer(seller, 50);
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 50);
-        sellOrder.commit(buyer, 0);
-        vm.stopPrank();
-        
-        vm.warp(131); // Warp past timeout (should still fail)
-        vm.startPrank(buyer);
-        vm.expectRevert(Order.TimeoutExpired.selector);
-        sellOrder.refund(buyer, 0);
-        vm.stopPrank();
-
-        // Refund buyer offer 
-        vm.warp(31);
-        vm.startPrank(buyer);
-        sellOrder.refund(buyer, 0);
-        vm.stopPrank();
-
-        // TODO: Test double refund
-
-        // TODO: Confirm proper money movement
-    }
-
-    function testFailSubmittingOfferTwiceFails() public {
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        address seller = address(0x1234567890123456784012345678901234567829);
-        address buyer = address(0x2234567890123456754012345678901234567821);
-
-        // Create a sell order
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        token.transfer(buyer, 20);
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 15, 5, 50, 'ipfs://somedata');
-        vm.stopPrank();
-
-        token.transfer(buyer, 20);
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 15, 5, 50, 'ipfs://somedata');
-        vm.stopPrank();
-    }
-
-    function testHappyPath() public {
-        // Setup
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        address seller = address(0x1234567890123456784012345678901234567829);
-        address buyer1 = address(0x2234567890123456754012345678901234567821);
-        address buyer2 = address(0x5234567890123456754012345678901234567822);
-
-        // Create a sell order
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        // Submit an offer from buyer1
-        token.transfer(buyer1, 20);
-        vm.startPrank(buyer1);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 20, 5, 50, 'ipfs://somedata');
-        vm.stopPrank();
-        (, uint256 offer1Price, uint256 offer1Cost, , , , , , ) = sellOrder
-            .offers(buyer1, 0);
-        require(offer1Price == 20, 'offer price1 is not 15');
-        require(offer1Cost == 5, 'offer cost1 is not 5');
-        require(
-            token.balanceOf(address(sellOrder)) >= 20,
-            'transfer did not occur '
-        );
-
-        // Submit an offer from buyer2
-        token.transfer(buyer2, 20);
-        vm.startPrank(buyer2);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 10, 10, 50, 'ipfs://somedata');
-        vm.stopPrank();
-        (, uint256 offer2price, uint256 offer2cost, , , , , , ) = sellOrder
-            .offers(buyer2, 0);
-        require(offer2price == 10, 'offer price2 is not 10');
-        require(offer2cost == 10, 'offer cost2 is not 10');
-
-        // Confirm buyer2's offer
-        token.transfer(seller, 50);
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 50);
-        sellOrder.commit(buyer2, 0);
-        vm.stopPrank();
-
-        (Order.State offerState1, , , , , , , , ) = sellOrder.offers(
-            buyer2,
-            0
-        );
-        require(
-            offerState1 == Order.State.Committed,
-            'state is not committed'
-        );
-        require(
-            token.balanceOf(address(sellOrder)) == 80,
-            'Sell order does not have 80 tokens'
-        );
-
-        // Confirm the order
-        vm.prank(buyer2);
-        sellOrder.confirm(buyer2, 0);
-
-        (Order.State offerState2, , , , , , , , ) = sellOrder.offers(
-            buyer2,
-            0
-        );
-        require(offerState2 == Order.State.Closed, 'state is not Closed');
-
-        require(
-            token.balanceOf(sellOrder.maker()) == 60, // 60 = payment + stake
-            'seller did not get paid'
-        );
-        require(
-            token.balanceOf(buyer2) == 10, // stake
-            'buyer did not get their stake back'
-        );
-    }
-
-    function testFailsSellerBuysTheirOwnOrder() public {
-        // Setup
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        address seller = address(0x1234567890123456784012345678901234567829);
-
-        // Create a sell order
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        // Submit an offer from seller
-        token.transfer(seller, 20);
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 15, 5, 50, 'ipfs://somedata');
-        vm.stopPrank();
-    }
-
-    function testOrderBookFees() public {
-        // Setup
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 200);
-
-        address seller = address(0x1234567890123456784012345678901234567829);
-        address buyer1 = address(0x2234567890123456754012345678901234567821);
-
-        // Create a sell order
-
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        // Submit an offer
-        token.transfer(buyer1, 100);
-        vm.startPrank(buyer1);
-        token.approve(address(sellOrder), 100);
-        sellOrder.submitOffer(0, 1, 100, 0, 50, 'ipfs://somedata');
-        vm.stopPrank();
-
-        // Commit to the offer
-        token.transfer(seller, 50);
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 50);
-        sellOrder.commit(buyer1, 0);
-        vm.stopPrank();
-
-        // Confirm the order
-        vm.prank(buyer1);
-        sellOrder.confirm(buyer1, 0);
-
-        // Check that the order book got 1 token
-        require(
-            token.balanceOf(book.owner()) == 1,
-            'order book owner did not get 1 token'
-        );
-
-        // Check that the seller got 99 tokens, plus their 50 stake back
-        require(
-            token.balanceOf(seller) == 99 + 50,
-            'seller did not get 1 token'
-        );
-    }
-
-    function testCommitBatch() public {
-        // Setup
-        ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 200);
-        address seller = address(0x1234567890123456784012345678901234567829);
-        address buyer1 = address(0x2234567890123456754012345678901234567821);
-        address buyer2 = address(0x5234567890123456754012345678901234567822);
-
-        // Create a sell order
-        Order sellOrder = book.createOrder(
-            seller,
-            token,
-            'ipfs://metadata',
-            100,
-            false
-        );
-
-        // Submit an offer from buyer1
-        token.transfer(buyer1, 20);
-        vm.startPrank(buyer1);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 15, 5, 50, 'ipfs://somedata');
-        vm.stopPrank();
-        (, uint256 offer1Price, uint256 offer1Cost, , , , , , ) = sellOrder
-            .offers(buyer1, 0);
-        require(offer1Price == 15, 'offer price1 is not 15');
-        require(offer1Cost == 5, 'offer cost1 is not 5');
-        require(
-            token.balanceOf(address(sellOrder)) >= 15,
-            'transfer did not occur '
-        );
-
-        // Submit an offer from buyer2
-        token.transfer(buyer2, 20);
-        vm.startPrank(buyer2);
-        token.approve(address(sellOrder), 20);
-        sellOrder.submitOffer(0, 1, 10, 10, 50, 'ipfs://somedata');
-        vm.stopPrank();
-        (, uint256 offer2price, uint256 offer2cost, , , , , , ) = sellOrder
-            .offers(buyer2, 0);
-        require(offer2price == 10, 'offer price2 is not 10');
-        require(offer2cost == 10, 'offer cost2 is not 10');
-
-        // Confirm both buyers' offers
-        token.transfer(seller, 100);
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 100);
-        address[] memory buyers = new address[](2);
-        uint32[] memory offerIndices = new uint32[](2);
-        buyers[0] = buyer1;
-        offerIndices[0] = 0;
-        buyers[1] = buyer2;
-        offerIndices[1] = 0;
-        sellOrder.commitBatch(buyers, offerIndices);
-        vm.stopPrank();
-
-        (Order.State offerState1, , , , , , , , ) = sellOrder.offers(
-            buyer2,
-            0
-        );
-        require(
-            offerState1 == Order.State.Committed,
-            'state is not committed'
-        );
-        require(
-            token.balanceOf(address(sellOrder)) == 125,
-            'Sell order does not have 125 tokens'
-        );
-
-        // Confirm the order
-        vm.prank(buyer2);
-        sellOrder.confirm(buyer2, 0);
-
-        (Order.State offerState2, , , , , , , , ) = sellOrder.offers(
-            buyer2,
-            0
-        );
-        require(offerState2 == Order.State.Closed, 'state is not Closed');
-
-        require(
-            token.balanceOf(sellOrder.maker()) == 60, // 60 = payment + stake
-            'seller did not get paid'
-        );
-        require(
-            token.balanceOf(buyer2) == 10, // stake
-            'buyer did not get their stake back'
-        );
-    }
-}
-
-contract CancelationTest is Test {
     Order sellOrder;
     address DAO = address(0x4234567890123456784012345678901234567821);
-    address seller = address(0x1234567890123456784012345678901234567829);
-    ERC20Mock token;
-    OrderBook book;
-
-    function setUp() public {
-        vm.prank(DAO);
-        book = new OrderBook();
-
-        token = new ERC20Mock('wETH', 'WETH', address(this), 20000);
-
-        // Create a sell order
-        sellOrder = book.createOrder(
-            seller,
-            token, // stake
-            'ipfs://metadata',
-            100,
-            false
-        );
-    }
-
-    function testBuyerCancels() public {
-        address buyer = address(0x4634567890123456784012345678901234567821);
-
-        token.transfer(buyer, 100);
-        token.transfer(seller, 50);
-
-        uint256 originalBuyer = token.balanceOf(buyer);
-        uint256 originalSeller = token.balanceOf(seller);
-
-        // Submit an offer
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), 100);
-        sellOrder.submitOffer(0, 1, 100, 0, 50, 'ipfs://somedata');
-        vm.stopPrank();
-
-        // Commit to the offer
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 50);
-        sellOrder.commit(buyer, 0);
-        vm.stopPrank();
-
-        // buyer canceled
-        vm.prank(buyer);
-        sellOrder.cancel(buyer, 0);
-
-        (, , , , , , bool sellerCanceled, bool buyerCanceled, ) = sellOrder
-            .offers(buyer, 0);
-        require(buyerCanceled, 'buyer did not cancel');
-        require(!sellerCanceled, 'sellerCanceled canceled');
-
-        // seller canceled
-        vm.prank(seller);
-        sellOrder.cancel(buyer, 0);
-
-        require(
-            token.balanceOf(buyer) == originalBuyer,
-            'buyer should be cleared'
-        );
-        require(
-            token.balanceOf(seller) == originalSeller,
-            'seller should be cleared'
-        );
-
-        (Order.State offerState2, , , , , , , , ) = sellOrder.offers(
-            buyer,
-            0
-        );
-        require(offerState2 == Order.State.Closed, 'state is not Closed');
-    }
-
-    function buyAndCommit(address buyer, uint32 index) public {
-        token.transfer(buyer, 100);
-        token.transfer(seller, 50);
-
-        // Submit an offer
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), 100);
-        sellOrder.submitOffer(index, 1, 100, 0, 50, 'ipfs://somedata');
-        vm.stopPrank();
-
-        // Commit to the offer
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), 50);
-        sellOrder.commit(buyer, index);
-        vm.stopPrank();
-    }
-
-    function testFailIfSellerCancelsAfterCanceled() public {
-        address buyer = address(0x3634567890123456784012345678901234567822);
-        buyAndCommit(buyer, 0);
-
-        vm.prank(seller);
-        sellOrder.cancel(buyer, 0);
-        vm.prank(buyer);
-        sellOrder.cancel(buyer, 0);
-
-        vm.prank(seller);
-        sellOrder.cancel(buyer, 0);
-    }
-
-    function testFailIfBuyerCancelsAfterCancelTwice() public {
-        address buyer = address(0x3634567890123456784012345678901234567822);
-        buyAndCommit(buyer, 0);
-
-        vm.prank(seller);
-        sellOrder.cancel(buyer, 0);
-        vm.prank(buyer);
-        sellOrder.cancel(buyer, 0);
-
-        vm.prank(buyer);
-        sellOrder.cancel(buyer, 0);
-    }
-
-    function testFailIfTryingToCancelSomeoneElsesOrder() public {
-        address buyer = address(0x3634567890123456784012345678901234567822);
-        buyAndCommit(buyer, 0);
-
-        address meanieMcNoGooderFace = address(
-            0x1634567890123456784012345678901234569824
-        );
-        vm.prank(meanieMcNoGooderFace);
-        sellOrder.cancel(buyer, 0);
-    }
-
-    function testMultipleOffers() public {
-        address buyer = address(0x3634567890123456784012345678901234567822);
-        buyAndCommit(buyer, 0);
-        buyAndCommit(buyer, 1);
-
-        (Order.State offerState0, , , , , , , , ) = sellOrder.offers(
-            buyer,
-            0
-        );
-        (Order.State offerState1, , , , , , , , ) = sellOrder.offers(
-            buyer,
-            1
-        );
-
-        require(
-            offerState0 == Order.State.Committed,
-            'state is not Committed'
-        );
-
-        require(
-            offerState1 == Order.State.Committed,
-            'state is not Committed'
-        );
-    }
-
-    function testFailInactiveOrder() public {
-        vm.prank(seller);
-        sellOrder.setActive(false);
-
-        address buyer = address(0x3634567890123456784012345678901234567822);
-        buyAndCommit(buyer, 0);
-    }
-
-    function testFailIfNotSellerCallsSetActive() public {
-        sellOrder.setActive(false);
-    }
-
-    function testCanSetActiveAndInactive() public {
-        vm.prank(seller);
-        sellOrder.setActive(false);
-        require(!sellOrder.active(), 'sell order is active');
-
-        vm.prank(seller);
-        sellOrder.setActive(true);
-        require(sellOrder.active(), 'sell order is inactive');
-    }
-}
-
-contract QuantityTest is Test {
-    Order sellOrder;
-    address DAO = address(0x4234567890123456784012345678901234567821);
-    address seller = address(0x1234567890123456784012345678901234567829);
+    address maker = address(0x1234567890123456784012345678901234567829);
+    address taker1 = address(0x2234567890123456754012345678901234567821);
+    address taker2 = address(0x5234567890123456754012345678901234567822);
     ERC20Mock token;
     OrderBook book;
     uint128 sellersStake = 5;
@@ -547,99 +25,552 @@ contract QuantityTest is Test {
 
         // Create a sell order
         sellOrder = book.createOrder(
-            seller,
+            maker,
             token,
             'ipfs://metadata',
             100,
             false
         );
+
+        assert(address(sellOrder.token()) == address(token));
+        assert(sellOrder.active());
     }
 
-    function testPurchasingWithQuantity() public {
-        address buyer = address(0x2934567890123456784012345678901234567234);
+    function submitOffer(
+        address taker,
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    ) public {
+        // Get initial balances
+        uint256 takerStartBalance = token.balanceOf(taker);
+        uint256 orderStartBalance = token.balanceOf(address(sellOrder));
 
-        uint32 quantity = 10;
-        uint32 price = 10;
-        uint32 cost = 2;
+        // Submit an offer from taker
+        vm.startPrank(taker);
+        sellOrder.submitOffer(index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit, 'ipfs://somedata');
+        vm.stopPrank();
+        
+        (Order.State offerState, uint256 offerPrice, uint256 offerCost, , , , , , ) = sellOrder
+            .offers(taker, index);
+        require(offerState == Order.State.Open, 'incorrect offer state');
+        require(offerPrice == pricePerUnit, 'incorrect offer price');
+        require(offerCost == costPerUnit, 'incorrect offer cost');
+        
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit - pricePerUnit) * quantity;
+        }
+
+        require(
+            token.balanceOf(address(sellOrder)) == orderStartBalance + transferAmount,
+            'incorrect transfer to sell order'
+        );
+        require(
+            token.balanceOf(taker) == takerStartBalance - transferAmount,
+            'incorrect transfer from taker'
+        );
+    }
+
+    function toSignature(
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(v, r, s);
+    }
+
+    function testSubmitOfferFuzz(
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    )  public {
+        vm.assume(quantity < 10000000000000000000000000);
+        vm.assume(pricePerUnit < 10000000000000000000000000000);
+        vm.assume(costPerUnit < 10000000000000000000000000000);
+        vm.assume(sellerStakePerUnit < 10000000000000000000000000000);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+    }
+
+    function submitOfferBase(address taker)  public {
         uint32 index = 0;
+        uint32 quantity = 1;
+        uint128 pricePerUnit = 1;
+        uint128 costPerUnit = 1;
+        uint128 sellerStakePerUnit = 1;
 
-        token.transfer(buyer, price * quantity);
-        token.transfer(seller, sellersStake * quantity);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
 
-        uint256 originalSeller = token.balanceOf(seller);
+        token.mint(taker, transferAmount);
+        vm.startPrank(taker);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(taker, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+    }
 
-        // Submit an offer
-        vm.startPrank(buyer);
-        token.approve(address(sellOrder), quantity * price);
-        sellOrder.submitOffer(index, quantity, price, cost, sellersStake, 'ipfs://somedata');
+    function testSubmitOfferBase() public {
+        submitOfferBase(taker1);
+    }
+
+    function testFailSubmitOfferLacksToken()  public {
+        uint32 index = 0;
+        uint32 quantity = 1;
+        uint128 pricePerUnit = 1;
+        uint128 costPerUnit = 1;
+        uint128 sellerStakePerUnit = 1;
+
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount - 1);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount - 1);
+        vm.stopPrank();
+        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+    }
+
+    function testFailSubmitOfferInactive()  public {
+        vm.startPrank(maker);
+        sellOrder.setActive(false);
+        vm.stopPrank();
+        
+        submitOfferBase(taker1);
+
+        vm.startPrank(maker);
+        sellOrder.setActive(true);
+        vm.stopPrank();
+    }
+
+    function testFailSubmitOfferTwice()  public {
+        submitOfferBase(taker1);
+        submitOfferBase(taker1);
+    }
+
+    function testSubmitTwoOffers()  public {
+        submitOfferBase(taker1);
+        submitOfferBase(taker2);
+    }
+
+    function testFailSubmitOfferMaker()  public {
+        submitOfferBase(maker);
+    }
+
+    function testFailSubmitOfferCommitted()  public {
+        submitOfferBase(taker1);
+        commitOffer(taker1, 0);
+        submitOfferBase(taker1);
+    }
+
+    function testWithdrawOffer() public {
+        submitOfferBase(taker1);
+
+        vm.startPrank(taker1);
+        sellOrder.withdrawOffer(0);
         vm.stopPrank();
 
-        // Commit to the offer
-        vm.startPrank(seller);
-        token.approve(address(sellOrder), sellersStake * quantity);
-        sellOrder.commit(buyer, index);
-        vm.stopPrank();
-
-        // Confirm the offer
-        vm.startPrank(buyer);
-        sellOrder.confirm(buyer, index);
-        vm.stopPrank();
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, 0);
+        require(offerState == Order.State.Closed, 'incorrect offer state');
 
         require(
-            token.balanceOf(buyer) == 0,
-            'buyer should be cleared'
+            token.balanceOf(address(sellOrder)) == 0,
+            'incorrect transfer to sell order'
         );
-
-        // Check the buyer and seller got paid
-        uint256 total = price * quantity;
-        uint256 toOrderBook = (total * IOrderBook(book).fee()) /
-            1000000;
         require(
-            token.balanceOf(seller) - originalSeller == (total - toOrderBook),
-            'seller should be paid'
+            token.balanceOf(taker1) == 1,
+            'incorrect transfer from taker'
+        );
+    }
+
+    function testWithdrawOfferFuzz(
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    )  public {
+        vm.assume(quantity < 10000000000000000000000000);
+        vm.assume(pricePerUnit < 10000000000000000000000000000);
+        vm.assume(costPerUnit < 10000000000000000000000000000);
+        vm.assume(sellerStakePerUnit < 10000000000000000000000000000);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+
+        vm.startPrank(taker1);
+        sellOrder.withdrawOffer(index);
+        vm.stopPrank();
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        require(offerState == Order.State.Closed, 'incorrect offer state');
+
+        require(
+            token.balanceOf(address(sellOrder)) == 0,
+            'incorrect transfer to sell order'
+        );
+        require(
+            token.balanceOf(taker1) == transferAmount,
+            'incorrect transfer from taker'
+        );
+    }
+
+    function testFailWithdrawOfferTwice() public {
+        submitOfferBase(taker1);
+
+        vm.startPrank(taker1);
+        sellOrder.withdrawOffer(0);
+        sellOrder.withdrawOffer(0);
+        vm.stopPrank();
+    }
+
+    function testFailWithdrawClosedOffer() public {
+        vm.startPrank(taker1);
+        sellOrder.withdrawOffer(0);
+        vm.stopPrank();
+    }
+
+    function testFailWithdrawOfferMaker() public {
+        submitOfferBase(taker1);
+
+        vm.startPrank(maker);
+        sellOrder.withdrawOffer(0);
+        vm.stopPrank();
+    }
+
+    function testFailWithdrawOfferCommitted()  public {
+        submitOfferBase(taker1);
+        commitOffer(taker1, 0);
+        vm.startPrank(taker1);
+        sellOrder.withdrawOffer(0);
+        vm.stopPrank();
+    }
+
+    function commitOffer(
+        address taker, 
+        uint32 index
+    ) public {
+        // Get initial balances
+        uint256 makerStartBalance = token.balanceOf(maker);
+        uint256 orderStartBalance = token.balanceOf(address(sellOrder));
+
+        // Commit to an offer from maker
+        vm.startPrank(maker);
+        sellOrder.commit(taker, index);
+        vm.stopPrank();
+        
+        (Order.State offerState, , , uint128 sellerStakePerUnit , , , , , uint32 quantity) = sellOrder
+            .offers(taker, index);
+        require(offerState == Order.State.Committed, 'incorrect offer state');
+        
+        uint128 transferAmount = sellerStakePerUnit * quantity;
+
+        require(
+            token.balanceOf(address(sellOrder)) == orderStartBalance + transferAmount,
+            'incorrect transfer to sell order'
+        );
+        require(
+            token.balanceOf(maker) == makerStartBalance - transferAmount,
+            'incorrect transfer from maker'
+        );
+    }
+
+    function testCommitOfferBase() public {
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+    }
+
+    function testCommitOfferFuzz(
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    )  public {
+        vm.assume(quantity < 10000000000000000000000000);
+        vm.assume(pricePerUnit < 10000000000000000000000000000);
+        vm.assume(costPerUnit < 10000000000000000000000000000);
+        vm.assume(sellerStakePerUnit < 10000000000000000000000000000);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+
+        uint128 makerStakeAmount = sellerStakePerUnit * quantity;
+        token.mint(maker, makerStakeAmount);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), makerStakeAmount);
+        vm.stopPrank();
+        commitOffer(taker1, index);
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        require(offerState == Order.State.Committed, 'incorrect offer state');
+    }
+
+    function testFailCommitOfferBaseLacksTokens() public {
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 0);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+    }
+
+    function testFailCommitOfferNotMaker() public {
+        submitOfferBase(taker1);
+
+        token.mint(taker2, 1);
+        vm.startPrank(taker2);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+    }
+
+    function testFailCommitOfferTaker() public {
+        submitOfferBase(taker1);
+
+        token.mint(taker1, 1);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+    }
+
+    function testFailCommitOfferClosed() public {
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 0);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+    }
+
+    function testCommitOfferBatch() public {
+        submitOfferBase(taker1);
+        submitOfferBase(taker2);
+
+        token.mint(maker, 2);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 2);
+        vm.stopPrank();
+        
+        // Get initial balances
+        uint256 makerStartBalance = token.balanceOf(maker);
+        uint256 orderStartBalance = token.balanceOf(address(sellOrder));
+
+        // Commit to an offer from maker
+        address[] memory takers = new address[](2);
+        uint32[] memory indicies = new uint32[](2);
+        takers[0] = taker1;
+        indicies[0] = 0;
+        takers[1] = taker2;
+        indicies[1] = 0;
+        vm.startPrank(maker);
+        sellOrder.commitBatch(takers, indicies);
+        vm.stopPrank();
+        
+        (Order.State offerState, , , , , , , , ) = sellOrder
+            .offers(taker1, 0);
+        require(offerState == Order.State.Committed, 'incorrect offer state');
+
+        require(
+            token.balanceOf(address(sellOrder)) == orderStartBalance + 2,
+            'incorrect transfer to sell order'
+        );
+        require(
+            token.balanceOf(maker) == makerStartBalance - 2,
+            'incorrect transfer from maker'
+        );
+    }
+
+    function confirmOffer(
+        address taker,
+        address from, 
+        uint32 index
+    ) public {
+        // Get initial balances
+        uint256 makerStartBalance = token.balanceOf(maker);
+        uint256 takerStartBalance = token.balanceOf(taker);
+        uint256 daoStartBalance = token.balanceOf(DAO);
+        
+        (, uint128 pricePerUnit, uint128 costPerUnit, uint128 sellerStakePerUnit, , , , , uint32 quantity) = sellOrder.offers(taker, index);
+
+        // Confirm to an offer from maker
+        vm.startPrank(from);
+        sellOrder.confirm(taker, index);
+        vm.stopPrank();
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker, index);
+        require(offerState == Order.State.Closed, 'incorrect offer state');
+        
+        uint256 total = (pricePerUnit + sellerStakePerUnit) * quantity;
+        uint256 toDao = (total * IOrderBook(book).fee()) / 1000000;
+
+        require(
+            token.balanceOf(address(sellOrder)) == 0,
+            'sell order should have no balance'
         );
 
-        // Check the state
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
-            buyer,
-            index
+        require(
+            token.balanceOf(maker) == makerStartBalance + total - toDao,
+            'incorrect transfer to seller'
         );
-        require(offerState == Order.State.Closed, 'state is not Closed');
-    }
-}
 
-contract OrderBookTest is Test {
-    function testFailOnlyOwnerCanSetFees() public {
-        address owner = address(0x1234567890123456784012345678901234567829);
-        vm.prank(owner);
-        OrderBook book = new OrderBook();
-        book.setFee(10);
-    }
+        require(
+            token.balanceOf(DAO) == daoStartBalance + toDao,
+            'incorrect transfer to DAO'
+        );
 
-    function testFailOnlyOwnerCanSetOwner() public {
-        address owner = address(0x1234567890123456784012345678901234567829);
-        vm.prank(owner);
-        OrderBook book = new OrderBook();
-        book.setOwner(address(0x4234567890123456784012345678901234567822));
-    }
-
-    function testOwnerCanSetFees() public {
-        address owner = address(0x1234567890123456784012345678901234567829);
-        vm.prank(owner);
-        OrderBook book = new OrderBook();
-
-        vm.prank(owner);
-        book.setFee(10);
-        require(book.fee() == 10, 'fee is not 10');
+        if (costPerUnit > pricePerUnit) {
+             require(
+                token.balanceOf(taker) == takerStartBalance + (costPerUnit - pricePerUnit) * quantity,
+                'incorrect transfer to buyer'
+            );
+        } else {
+            require(
+                token.balanceOf(taker) == 0,
+                'incorrect transfer to buyer'
+            );
+        }
     }
 
-    function testOwnerCanSetOwner() public {
-        address owner = address(0x1234567890123456784012345678901234567829);
-        vm.prank(owner);
-        OrderBook book = new OrderBook();
+    function testConfirmOffer() public {
+        vm.warp(0);
+        submitOfferBase(taker1);
 
-        vm.prank(owner);
-        book.setOwner(owner);
-        require(book.owner() == owner, 'owner is not owner');
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+
+        vm.warp(0);
+        confirmOffer(taker1, taker1, 0);
+    }
+
+    function testConfirmOfferMaker() public {
+        vm.warp(0);
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+
+        vm.warp(110);
+        confirmOffer(taker1, maker, 0);
+    }
+
+    function testFailConfirmOfferMakerTimeout() public {
+        vm.warp(0);
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+
+        vm.warp(10);
+        confirmOffer(taker1, maker, 0);
+    }
+
+    function testConfirmOfferBatch() public {
+        vm.warp(0);
+        submitOfferBase(taker1);
+        submitOfferBase(taker2);
+
+        token.mint(maker, 2);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 2);
+        vm.stopPrank();
+        commitOffer(taker1, 0);
+        commitOffer(taker2, 0);
+
+        vm.warp(110);
+        address[] memory takers = new address[](2);
+        uint32[] memory indicies = new uint32[](2);
+        takers[0] = taker1;
+        indicies[0] = 0;
+        takers[1] = taker2;
+        indicies[1] = 0;
+        vm.startPrank(maker);
+        sellOrder.confirmBatch(takers, indicies);
+        vm.stopPrank();
+    }
+
+    function testConfirmOfferFuzz(
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    )  public {
+        vm.assume(quantity < 10000000000000000000000000);
+        vm.assume(pricePerUnit < 10000000000000000000000000000);
+        vm.assume(costPerUnit < 10000000000000000000000000000);
+        vm.assume(sellerStakePerUnit < 10000000000000000000000000000);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+
+        uint128 makerStakeAmount = sellerStakePerUnit * quantity;
+        token.mint(maker, makerStakeAmount);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), makerStakeAmount);
+        vm.stopPrank();
+        commitOffer(taker1, index);
+
+        confirmOffer(taker1, taker1, index);
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        require(offerState == Order.State.Closed, 'incorrect offer state');
+    }
+
+    function testFailConfirmOfferBaseNotCommitted() public {
+        submitOfferBase(taker1);
+        confirmOffer(taker1, taker1, 0);
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -823,3 +823,40 @@ contract SellOrderTest is Test {
         require(offerState == Order.State.Closed, 'incorrect offer state');
     }
 }
+
+contract OrderBookTest is Test {
+    function testFailOnlyOwnerCanSetFees() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+        book.setFee(10);
+    }
+
+    function testFailOnlyOwnerCanSetOwner() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+        book.setOwner(address(0x4234567890123456784012345678901234567822));
+    }
+
+    function testOwnerCanSetFees() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+
+        vm.prank(owner);
+        book.setFee(10);
+        require(book.fee() == 10, 'fee is not 10');
+    }
+
+    function testOwnerCanSetOwner() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+
+        vm.prank(owner);
+        book.setOwner(owner);
+        require(book.owner() == owner, 'owner is not owner');
+    }
+}
+

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -50,22 +50,39 @@ contract SellOrderTest is Test {
 
         // Submit an offer from taker
         vm.startPrank(taker);
-        sellOrder.submitOffer(index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit, 'ipfs://somedata');
+        sellOrder.submitOffer(
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit,
+            'ipfs://somedata'
+        );
         vm.stopPrank();
-        
-        (Order.State offerState, uint256 offerPrice, uint256 offerCost, , , , , , ) = sellOrder
-            .offers(taker, index);
+
+        (
+            Order.State offerState,
+            uint256 offerPrice,
+            uint256 offerCost,
+            ,
+            ,
+            ,
+            ,
+            ,
+
+        ) = sellOrder.offers(taker, index);
         require(offerState == Order.State.Open, 'incorrect offer state');
         require(offerPrice == pricePerUnit, 'incorrect offer price');
         require(offerCost == costPerUnit, 'incorrect offer cost');
-        
+
         uint128 transferAmount = pricePerUnit * quantity;
         if (costPerUnit > pricePerUnit) {
             transferAmount += (costPerUnit - pricePerUnit) * quantity;
         }
 
         require(
-            token.balanceOf(address(sellOrder)) == orderStartBalance + transferAmount,
+            token.balanceOf(address(sellOrder)) ==
+                orderStartBalance + transferAmount,
             'incorrect transfer to sell order'
         );
         require(
@@ -88,7 +105,7 @@ contract SellOrderTest is Test {
         uint128 pricePerUnit,
         uint128 costPerUnit,
         uint128 sellerStakePerUnit
-    )  public {
+    ) public {
         vm.assume(quantity < 10000000000000000000000000);
         vm.assume(pricePerUnit < 10000000000000000000000000000);
         vm.assume(costPerUnit < 10000000000000000000000000000);
@@ -102,10 +119,17 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
     }
 
-    function submitOfferBase(address taker)  public {
+    function submitOfferBase(address taker) public {
         uint32 index = 0;
         uint32 quantity = 1;
         uint128 pricePerUnit = 1;
@@ -121,14 +145,21 @@ contract SellOrderTest is Test {
         vm.startPrank(taker);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
     }
 
     function testSubmitOffer() public {
         submitOfferBase(taker1);
     }
 
-    function testFailSubmitOfferLacksToken()  public {
+    function testFailSubmitOfferLacksToken() public {
         uint32 index = 0;
         uint32 quantity = 1;
         uint128 pricePerUnit = 1;
@@ -144,14 +175,21 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount - 1);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
     }
 
-    function testFailSubmitOfferInactive()  public {
+    function testFailSubmitOfferInactive() public {
         vm.startPrank(maker);
         sellOrder.setActive(false);
         vm.stopPrank();
-        
+
         submitOfferBase(taker1);
 
         vm.startPrank(maker);
@@ -159,21 +197,21 @@ contract SellOrderTest is Test {
         vm.stopPrank();
     }
 
-    function testFailSubmitOfferTwice()  public {
+    function testFailSubmitOfferTwice() public {
         submitOfferBase(taker1);
         submitOfferBase(taker1);
     }
 
-    function testSubmitTwoOffers()  public {
+    function testSubmitTwoOffers() public {
         submitOfferBase(taker1);
         submitOfferBase(taker2);
     }
 
-    function testFailSubmitOfferMaker()  public {
+    function testFailSubmitOfferMaker() public {
         submitOfferBase(maker);
     }
 
-    function testFailSubmitOfferCommitted()  public {
+    function testFailSubmitOfferCommitted() public {
         submitOfferBase(taker1);
         commitOffer(taker1, 0);
         submitOfferBase(taker1);
@@ -193,10 +231,7 @@ contract SellOrderTest is Test {
             token.balanceOf(address(sellOrder)) == 0,
             'incorrect transfer to sell order'
         );
-        require(
-            token.balanceOf(taker1) == 1,
-            'incorrect transfer from taker'
-        );
+        require(token.balanceOf(taker1) == 1, 'incorrect transfer from taker');
     }
 
     function testWithdrawOfferFuzz(
@@ -205,7 +240,7 @@ contract SellOrderTest is Test {
         uint128 pricePerUnit,
         uint128 costPerUnit,
         uint128 sellerStakePerUnit
-    )  public {
+    ) public {
         vm.assume(quantity < 10000000000000000000000000);
         vm.assume(pricePerUnit < 10000000000000000000000000000);
         vm.assume(costPerUnit < 10000000000000000000000000000);
@@ -219,13 +254,23 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
 
         vm.startPrank(taker1);
         sellOrder.withdrawOffer(index);
         vm.stopPrank();
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker1,
+            index
+        );
         require(offerState == Order.State.Closed, 'incorrect offer state');
 
         require(
@@ -261,7 +306,7 @@ contract SellOrderTest is Test {
         vm.stopPrank();
     }
 
-    function testFailWithdrawOfferCommitted()  public {
+    function testFailWithdrawOfferCommitted() public {
         submitOfferBase(taker1);
         commitOffer(taker1, 0);
         vm.startPrank(taker1);
@@ -269,10 +314,7 @@ contract SellOrderTest is Test {
         vm.stopPrank();
     }
 
-    function commitOffer(
-        address taker, 
-        uint32 index
-    ) public {
+    function commitOffer(address taker, uint32 index) public {
         // Get initial balances
         uint256 makerStartBalance = token.balanceOf(maker);
         uint256 orderStartBalance = token.balanceOf(address(sellOrder));
@@ -281,15 +323,25 @@ contract SellOrderTest is Test {
         vm.startPrank(maker);
         sellOrder.commit(taker, index);
         vm.stopPrank();
-        
-        (Order.State offerState, , , uint128 sellerStakePerUnit , , , , , uint32 quantity) = sellOrder
-            .offers(taker, index);
+
+        (
+            Order.State offerState,
+            ,
+            ,
+            uint128 sellerStakePerUnit,
+            ,
+            ,
+            ,
+            ,
+            uint32 quantity
+        ) = sellOrder.offers(taker, index);
         require(offerState == Order.State.Committed, 'incorrect offer state');
-        
+
         uint128 transferAmount = sellerStakePerUnit * quantity;
 
         require(
-            token.balanceOf(address(sellOrder)) == orderStartBalance + transferAmount,
+            token.balanceOf(address(sellOrder)) ==
+                orderStartBalance + transferAmount,
             'incorrect transfer to sell order'
         );
         require(
@@ -314,7 +366,7 @@ contract SellOrderTest is Test {
         uint128 pricePerUnit,
         uint128 costPerUnit,
         uint128 sellerStakePerUnit
-    )  public {
+    ) public {
         vm.assume(quantity < 10000000000000000000000000);
         vm.assume(pricePerUnit < 10000000000000000000000000000);
         vm.assume(costPerUnit < 10000000000000000000000000000);
@@ -328,7 +380,14 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
 
         uint128 makerStakeAmount = sellerStakePerUnit * quantity;
         token.mint(maker, makerStakeAmount);
@@ -337,7 +396,10 @@ contract SellOrderTest is Test {
         vm.stopPrank();
         commitOffer(taker1, index);
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker1,
+            index
+        );
         require(offerState == Order.State.Committed, 'incorrect offer state');
     }
 
@@ -387,7 +449,7 @@ contract SellOrderTest is Test {
         vm.startPrank(maker);
         token.approve(address(sellOrder), 2);
         vm.stopPrank();
-        
+
         // Get initial balances
         uint256 makerStartBalance = token.balanceOf(maker);
         uint256 orderStartBalance = token.balanceOf(address(sellOrder));
@@ -402,9 +464,8 @@ contract SellOrderTest is Test {
         vm.startPrank(maker);
         sellOrder.commitBatch(takers, indicies);
         vm.stopPrank();
-        
-        (Order.State offerState, , , , , , , , ) = sellOrder
-            .offers(taker1, 0);
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, 0);
         require(offerState == Order.State.Committed, 'incorrect offer state');
 
         require(
@@ -419,24 +480,37 @@ contract SellOrderTest is Test {
 
     function confirmOffer(
         address taker,
-        address from, 
+        address from,
         uint32 index
     ) public {
         // Get initial balances
         uint256 makerStartBalance = token.balanceOf(maker);
         uint256 takerStartBalance = token.balanceOf(taker);
         uint256 daoStartBalance = token.balanceOf(DAO);
-        
-        (, uint128 pricePerUnit, uint128 costPerUnit, uint128 sellerStakePerUnit, , , , , uint32 quantity) = sellOrder.offers(taker, index);
+
+        (
+            ,
+            uint128 pricePerUnit,
+            uint128 costPerUnit,
+            uint128 sellerStakePerUnit,
+            ,
+            ,
+            ,
+            ,
+            uint32 quantity
+        ) = sellOrder.offers(taker, index);
 
         // Confirm to an offer from maker
         vm.startPrank(from);
         sellOrder.confirm(taker, index);
         vm.stopPrank();
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker,
+            index
+        );
         require(offerState == Order.State.Closed, 'incorrect offer state');
-        
+
         uint256 total = (pricePerUnit + sellerStakePerUnit) * quantity;
         uint256 toDao = (total * IOrderBook(book).fee()) / 1000000;
 
@@ -456,8 +530,9 @@ contract SellOrderTest is Test {
         );
 
         if (costPerUnit > pricePerUnit) {
-             require(
-                token.balanceOf(taker) == takerStartBalance + (costPerUnit - pricePerUnit) * quantity,
+            require(
+                token.balanceOf(taker) ==
+                    takerStartBalance + (costPerUnit - pricePerUnit) * quantity,
                 'incorrect transfer to buyer'
             );
         } else {
@@ -540,7 +615,7 @@ contract SellOrderTest is Test {
         uint128 pricePerUnit,
         uint128 costPerUnit,
         uint128 sellerStakePerUnit
-    )  public {
+    ) public {
         vm.assume(quantity < 10000000000000000000000000);
         vm.assume(pricePerUnit < 10000000000000000000000000000);
         vm.assume(costPerUnit < 10000000000000000000000000000);
@@ -554,7 +629,14 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
 
         uint128 makerStakeAmount = sellerStakePerUnit * quantity;
         token.mint(maker, makerStakeAmount);
@@ -565,7 +647,10 @@ contract SellOrderTest is Test {
 
         confirmOffer(taker1, taker1, index);
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker1,
+            index
+        );
         require(offerState == Order.State.Closed, 'incorrect offer state');
     }
 
@@ -574,22 +659,32 @@ contract SellOrderTest is Test {
         confirmOffer(taker1, taker1, 0);
     }
 
-    function refundOffer(
-        address taker, 
-        uint32 index
-    ) public {
+    function refundOffer(address taker, uint32 index) public {
         // Get initial balances
         uint256 makerStartBalance = token.balanceOf(maker);
         uint256 takerStartBalance = token.balanceOf(taker);
-        
-        (, uint128 pricePerUnit, uint128 costPerUnit, , , , , , uint32 quantity) = sellOrder.offers(taker, index);
+
+        (
+            ,
+            uint128 pricePerUnit,
+            uint128 costPerUnit,
+            ,
+            ,
+            ,
+            ,
+            ,
+            uint32 quantity
+        ) = sellOrder.offers(taker, index);
 
         // Confirm to an offer from maker
         vm.startPrank(taker);
         sellOrder.refund(taker, index);
         vm.stopPrank();
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker,
+            index
+        );
         require(offerState == Order.State.Closed, 'incorrect offer state');
 
         require(
@@ -603,8 +698,9 @@ contract SellOrderTest is Test {
         );
 
         if (costPerUnit < pricePerUnit) {
-             require(
-                token.balanceOf(taker) == takerStartBalance + (pricePerUnit - costPerUnit) * quantity,
+            require(
+                token.balanceOf(taker) ==
+                    takerStartBalance + (pricePerUnit - costPerUnit) * quantity,
                 'incorrect transfer to buyer'
             );
         } else {
@@ -635,7 +731,7 @@ contract SellOrderTest is Test {
         uint128 pricePerUnit,
         uint128 costPerUnit,
         uint128 sellerStakePerUnit
-    )  public {
+    ) public {
         vm.assume(quantity < 10000000000000000000000000);
         vm.assume(pricePerUnit < 10000000000000000000000000000);
         vm.assume(costPerUnit < 10000000000000000000000000000);
@@ -649,7 +745,14 @@ contract SellOrderTest is Test {
         vm.startPrank(taker1);
         token.approve(address(sellOrder), transferAmount);
         vm.stopPrank();
-        submitOffer(taker1, index, quantity, pricePerUnit, costPerUnit, sellerStakePerUnit);
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
 
         uint128 makerStakeAmount = sellerStakePerUnit * quantity;
         token.mint(maker, makerStakeAmount);
@@ -660,7 +763,10 @@ contract SellOrderTest is Test {
 
         refundOffer(taker1, index);
 
-        (Order.State offerState, , , , , , , , ) = sellOrder.offers(taker1, index);
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker1,
+            index
+        );
         require(offerState == Order.State.Closed, 'incorrect offer state');
     }
 
@@ -691,5 +797,158 @@ contract SellOrderTest is Test {
         vm.startPrank(taker2);
         sellOrder.refund(taker1, 0);
         vm.stopPrank();
+    }
+
+    function cancelOffer(
+        address taker,
+        address from,
+        uint32 index
+    ) public {
+        // Get initial balances
+        uint256 makerStartBalance = token.balanceOf(maker);
+        uint256 takerStartBalance = token.balanceOf(taker);
+
+        (
+            ,
+            uint128 pricePerUnit,
+            uint128 costPerUnit,
+            uint128 sellerStakePerUnit,
+            ,
+            ,
+            bool makerCanceled,
+            bool takerCanceled,
+            uint32 quantity
+        ) = sellOrder.offers(taker, index);
+
+        // Cancel an offer
+        vm.startPrank(from);
+        sellOrder.cancel(taker, index);
+        vm.stopPrank();
+
+        (
+            Order.State offerState,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+            
+        ) = sellOrder.offers(taker, index);
+
+        if (makerCanceled || takerCanceled) {
+            require(offerState == Order.State.Closed, 'incorrect offer state');
+            require(
+                token.balanceOf(address(sellOrder)) == 0,
+                'sell order should have no balance'
+            );
+            require(
+                token.balanceOf(maker) == makerStartBalance + (sellerStakePerUnit * quantity),
+                'incorrect transfer to seller'
+            );
+            uint128 toBuyer = pricePerUnit * quantity;
+            if (costPerUnit > pricePerUnit) {
+                toBuyer += (costPerUnit - pricePerUnit) * quantity;
+            }
+            require(
+                token.balanceOf(taker) == takerStartBalance + toBuyer,
+                'incorrect transfer to buyer'
+            );
+        } else {
+            require(
+                offerState == Order.State.Committed,
+                'incorrect offer state'
+            );
+        }
+    }
+
+    function testCancelOffer() public {
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        
+        commitOffer(taker1, 0);
+
+        cancelOffer(taker1, taker1, 0);
+        cancelOffer(taker1, maker, 0);
+    }
+
+     function testCancelOnce() public {
+        submitOfferBase(taker1);
+
+        token.mint(maker, 1);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), 1);
+        vm.stopPrank();
+        
+        commitOffer(taker1, 0);
+
+        cancelOffer(taker1, taker1, 0);
+
+        (
+            Order.State offerState,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+            
+        ) = sellOrder.offers(taker1, 0);
+        require(
+            offerState == Order.State.Committed,
+            'incorrect offer state'
+        );
+    }
+
+    function testCancelOfferFuzz(
+        uint32 index,
+        uint32 quantity,
+        uint128 pricePerUnit,
+        uint128 costPerUnit,
+        uint128 sellerStakePerUnit
+    ) public {
+        vm.assume(quantity < 10000000000000000000000000);
+        vm.assume(pricePerUnit < 10000000000000000000000000000);
+        vm.assume(costPerUnit < 10000000000000000000000000000);
+        vm.assume(sellerStakePerUnit < 10000000000000000000000000000);
+        uint128 transferAmount = pricePerUnit * quantity;
+        if (costPerUnit > pricePerUnit) {
+            transferAmount += (costPerUnit + pricePerUnit) * quantity;
+        }
+
+        token.mint(taker1, transferAmount);
+        vm.startPrank(taker1);
+        token.approve(address(sellOrder), transferAmount);
+        vm.stopPrank();
+        submitOffer(
+            taker1,
+            index,
+            quantity,
+            pricePerUnit,
+            costPerUnit,
+            sellerStakePerUnit
+        );
+
+        uint128 makerStakeAmount = sellerStakePerUnit * quantity;
+        token.mint(maker, makerStakeAmount);
+        vm.startPrank(maker);
+        token.approve(address(sellOrder), makerStakeAmount);
+        vm.stopPrank();
+        commitOffer(taker1, index);
+
+        cancelOffer(taker1, taker1, index);
+        cancelOffer(taker1, maker, index);
+
+        (Order.State offerState, , , , , , , , ) = sellOrder.offers(
+            taker1,
+            index
+        );
+        require(offerState == Order.State.Closed, 'incorrect offer state');
     }
 }


### PR DESCRIPTION
This change is fairly large so I could use some thorough reviews. Summary of changes:
- Rename reject to refund
- Switch to cost model
   - if c > p: buyerstake = c - p
   - if p > c: refund = p - c
   - this introduces refunds, seller no longer gets p, buyer gets p if they have refund
- Refundable period is while timestamp < timeout, after that anyone can confirm
- Seller stake is moved to the offer

Completed comprehensive test suite overall