### PR TITLE
Added changing token dropdowns, updated UI to match figma

### DIFF
--- a/www/components/Layout.tsx
+++ b/www/components/Layout.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link';
 import { FadeIn } from './FadeIn';
 import cn from 'classnames';
 import { useRouter } from 'next/router';
-import { useWaitForTransaction, chain } from 'wagmi';
+import { useWaitForTransaction } from 'wagmi';
 
 export function InformationPageHeader() {
   return (
@@ -87,10 +87,6 @@ export function TabBar(props: { tab: 'buy' | 'sell' }) {
   );
 }
 
-export function getNetwork(props: any) {
-  return props.chain;
-}
-
 export function ConnectWalletLayout(props: {
   requireConnected: boolean;
   children: React.ReactNode;
@@ -100,7 +96,6 @@ export function ConnectWalletLayout(props: {
   const waitForTransaction = useWaitForTransaction({
     hash: props.txHash,
   });
-
   return (
     <div className="flex flex-col h-full">
       <div className="flex px-4 py-4  justify-between items-center w-full max-w-6xl mx-auto w-full">

--- a/www/components/Layout.tsx
+++ b/www/components/Layout.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link';
 import { FadeIn } from './FadeIn';
 import cn from 'classnames';
 import { useRouter } from 'next/router';
-import { useWaitForTransaction } from 'wagmi';
+import { useWaitForTransaction, chain } from 'wagmi';
 
 export function InformationPageHeader() {
   return (
@@ -87,6 +87,10 @@ export function TabBar(props: { tab: 'buy' | 'sell' }) {
   );
 }
 
+export function getNetwork(props: any) {
+  return props.chain;
+}
+
 export function ConnectWalletLayout(props: {
   requireConnected: boolean;
   children: React.ReactNode;
@@ -95,7 +99,7 @@ export function ConnectWalletLayout(props: {
   const router = useRouter();
   const waitForTransaction = useWaitForTransaction({
     hash: props.txHash,
-  })
+  });
 
   return (
     <div className="flex flex-col h-full">
@@ -164,7 +168,7 @@ export function ConnectWalletLayout(props: {
                       {chain.name}
                       <SwitchHorizontalIcon className="h-4 w-4 ml-2" />
                     </button>
-                    {waitForTransaction.status != "loading" &&
+                    {waitForTransaction.status != 'loading' && (
                       <button
                         className="bg-white border text-sm border-gray-200 rounded px-2 py-1 flex items-center font-mono hover:opacity-50"
                         onClick={() => openAccountModal()}
@@ -172,13 +176,13 @@ export function ConnectWalletLayout(props: {
                         {account.ensName ? account.ensName : keyDetails}
                         <FingerPrintIcon className="h-4 w-4 ml-2" />
                       </button>
-                    }
-                    {waitForTransaction.status == "loading" &&
+                    )}
+                    {waitForTransaction.status == 'loading' && (
                       <div className="animate-pulse bg-white border text-sm border-gray-200 rounded px-2 py-1 flex items-center font-mono hover:opacity-50">
                         Transaction pending
-                        <RefreshIcon className='animate-spin h-4 w-4 ml-2'/>
-                    </div>
-                    }
+                        <RefreshIcon className="animate-spin h-4 w-4 ml-2" />
+                      </div>
+                    )}
                   </FadeIn>
                 );
               }}

--- a/www/lib/tokenDropdown.tsx
+++ b/www/lib/tokenDropdown.tsx
@@ -1,4 +1,5 @@
-import tokenlist from '@eth-optimism/tokenlist';
+import optimismList from '@eth-optimism/tokenlist';
+import polygonList from '../node_modules/polygon-token-list/src/tokens/allTokens.json';
 
 const acceptedCoins = [
   'USDC',
@@ -10,6 +11,54 @@ const acceptedCoins = [
   'UST',
   'FRAX',
 ];
+
+const rinkebyList = [
+  {
+    name: 'Wrapped Ether',
+    address: '0xc778417E063141139Fce010982780140Aa0cD5Ab',
+    symbol: 'WETH',
+    decimals: 18,
+    chainId: 4,
+    logoURI: 'https://ethereum-optimism.github.io/logos/WETH.png',
+  },
+  {
+    name: 'Dai Stablecoin',
+    address: '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735',
+    symbol: 'DAI',
+    decimals: 18,
+    chainId: 4,
+    logoURI:
+      'https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.svg?v=010',
+  },
+  {
+    name: 'Maker',
+    address: '0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85',
+    symbol: 'MKR',
+    decimals: 18,
+    chainId: 4,
+    logoURI: 'https://ethereum-optimism.github.io/logos/MKR.png',
+  },
+  {
+    name: 'Uniswap',
+    address: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+    symbol: 'UNI',
+    decimals: 18,
+    chainId: 4,
+    logoURI: 'https://ethereum-optimism.github.io/logos/UNI.png',
+  },
+];
+
+export function networkDropDown(network: string) {
+  if (network === 'Rinkeby') {
+    return ddRinkebyList;
+  } else if (network === 'Optimism') {
+    return ddOptimismList;
+  } else if (network === 'Polygon') {
+    return ddPolygonList;
+  } else {
+    return [{ value: 'Custom', name: 'Custom Token', logo: '' }];
+  }
+}
 
 export function renderToken(
   props: any,
@@ -48,10 +97,25 @@ export function renderToken(
   }
 }
 
-export const optimismList = tokenlist.tokens
+export const ddOptimismList = optimismList.tokens
   .filter(
     (token) => acceptedCoins.includes(token.symbol) && token.chainId == 10
   )
+  .map((row) => {
+    return { value: row.address, name: row.symbol, logo: row.logoURI };
+  })
+  .concat([{ value: 'Custom', name: 'Custom Token', logo: '' }]);
+
+export const ddPolygonList = polygonList
+  .filter(
+    (token) => acceptedCoins.includes(token.symbol) && token.chainId == 137
+  )
+  .map((row) => {
+    return { value: row.address, name: row.symbol, logo: row.logoURI };
+  })
+  .concat([{ value: 'Custom', name: 'Custom Token', logo: '' }]);
+
+export const ddRinkebyList = rinkebyList
   .map((row) => {
     return { value: row.address, name: row.symbol, logo: row.logoURI };
   })

--- a/www/package.json
+++ b/www/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@eth-optimism/tokenlist": "git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git",
+    "@eth-optimism/tokenlist": "git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git#af613ec3c5e511dbd0dc7c9cdd3d6eda311905c6",
     "@heroicons/react": "^1.0.6",
     "@metamask/eth-sig-util": "^4.0.1",
     "@rainbow-me/rainbowkit": "^0.1.0",
@@ -27,6 +27,7 @@
     "next": "^12.1.6",
     "next-mdx-remote": "^3.0.8",
     "node-abort-controller": "^3.0.1",
+    "polygon-token-list":"git+https://github.com/maticnetwork/polygon-token-list.git#ce24aa9288aeb30db2dc788213706424bd34c540",
     "react": "18",
     "react-dom": "18",
     "react-select-search": "^3.0.9",

--- a/www/pages/sell/new.tsx
+++ b/www/pages/sell/new.tsx
@@ -124,14 +124,6 @@ function NewOrder() {
     router.push(`/buy/${orderAddress}`);
   }
 
-  function setTokenState(opt: any) {
-    if (opt === 'Custom') {
-      setState((s) => ({ ...s, token: '' }));
-    } else {
-      setState((s) => ({ ...s, token: opt }));
-    }
-  }
-
   let [customTokenDisabled, setCustomTokenDisabled] = useState(true);
 
   return (

--- a/www/pages/sell/new.tsx
+++ b/www/pages/sell/new.tsx
@@ -1,7 +1,12 @@
-import { useContractWrite, useSigner } from 'wagmi';
+import { chainId, useContractWrite, useSigner } from 'wagmi';
 import { OrderBook } from 'rwtp';
 import { useState } from 'react';
-import { ArrowRightIcon, RefreshIcon, XIcon } from '@heroicons/react/solid';
+import {
+  ArrowRightIcon,
+  ChevronDownIcon,
+  RefreshIcon,
+  XIcon,
+} from '@heroicons/react/solid';
 import { ethers } from 'ethers';
 import { toBn } from 'evm-bn';
 import { useRouter } from 'next/router';
@@ -9,10 +14,12 @@ import { ConnectWalletLayout } from '../../components/Layout';
 import { RequiresKeystore } from '../../lib/keystore';
 import { useEncryptionKeypair } from '../../lib/useEncryptionKey';
 import SelectSearch from 'react-select-search';
-import { renderToken, optimismList } from '../../lib/tokenDropdown';
+import { renderToken, networkDropDown } from '../../lib/tokenDropdown';
 import { DEFAULT_TOKEN } from '../../lib/constants';
 import cn from 'classnames';
 import { DEFAULT_OFFER_SCHEMA } from '../../lib/constants';
+import { useNetwork } from 'wagmi';
+import { valueFromAST } from 'graphql';
 
 async function postJSONToIPFS(data: any) {
   const result = await fetch('/api/uploadJson', {
@@ -31,13 +38,16 @@ async function postJSONToIPFS(data: any) {
 async function postFileToIPFS(file: Buffer) {
   const result = await fetch('/api/uploadFile', {
     method: 'POST',
-    body: file.toString("base64"),
+    body: file.toString('base64'),
   });
   const { cid } = await result.json();
   return cid;
 }
 
 function NewOrder() {
+  const { activeChain, chains, error, pendingChainId, switchNetwork } =
+    useNetwork();
+
   const [state, setState] = useState({
     title: '',
     description: '',
@@ -91,19 +101,14 @@ function NewOrder() {
         state.buyersCost.toString(),
         decimals
       ).toHexString(),
-      suggestedTimeout: 
-      toBn(
+      suggestedTimeout: toBn(
         (60 * 60 * 24 * 7).toString(),
         decimals
       ).toHexString(),
     });
 
     const tx = await book.writeAsync({
-      args: [
-        await signer.data.getAddress(),
-        `ipfs://${cid}`,
-        false
-      ],
+      args: [await signer.data.getAddress(), `ipfs://${cid}`, false],
     });
 
     setTxHash(tx.hash);
@@ -119,18 +124,26 @@ function NewOrder() {
     router.push(`/buy/${orderAddress}`);
   }
 
+  function setTokenState(opt: any) {
+    if (opt === 'Custom') {
+      setState((s) => ({ ...s, token: '' }));
+    } else {
+      setState((s) => ({ ...s, token: opt }));
+    }
+  }
+
   let [customTokenDisabled, setCustomTokenDisabled] = useState(true);
 
   return (
     <ConnectWalletLayout requireConnected={true} txHash={txHash}>
-      <div className="px-4 py-4 max-w-6xl mx-auto">
-        <div className="font-serif mb-12 mt-12 text-2xl">
+      <div className="px-4 py-4 max-w-3xl mx-auto">
+        <div className="font-serif mb-2 mt-12 text-2xl">
           Create a new sell listing
         </div>
-        <p className="mb-8">Sell anything, from a pack of gum to a ferrari.</p>
+        <p className="mb-10">Sell anything, from a pack of gum to a ferrari.</p>
 
-        <div className="flex flex-col">
-          <label className="flex flex-col mb-8">
+        <div className="flex flex-col space-y-8">
+          <label className="flex flex-col">
             <strong className="mb-1 text-sm">Title</strong>
             <input
               className="font-sans border px-4 py-2 rounded"
@@ -141,7 +154,7 @@ function NewOrder() {
               value={state.title}
             />
           </label>
-          <label className="flex flex-col mb-8">
+          <label className="flex flex-col">
             <strong className="mb-1 text-sm">Description</strong>
             <textarea
               className="border px-4 py-2 rounded"
@@ -152,24 +165,25 @@ function NewOrder() {
               value={state.description}
             />
           </label>
-          <div className="flex flex-col mb-8">
+          <div className="flex flex-col">
             <strong className="mb-1 text-sm">Image</strong>
-            <label className='flex flex-row content-center'>
+            <label className="flex flex-row content-center">
               <input
                 type="text"
-                className="px-4 py-2 border my-auto flex-grow"
-                placeholder='ipfs://cid or https://image.jpg'
+                className="px-4 py-2 border rounded my-auto flex-grow"
+                placeholder="ipfs://cid or https://image.jpg"
                 hidden={imageUploading}
                 value={state.primaryImage}
                 onChange={(e) => {
                   setShowImagePreview(false);
-                  setState((s) => ({ ...s, primaryImage: e.target.value }))
+                  setState((s) => ({ ...s, primaryImage: e.target.value }));
                 }}
                 onBlur={() => setShowImagePreview(true)}
               />
               <p
-                className='my-auto px-5 text-center'
-                hidden={!!state.primaryImage || imageUploading}>
+                className="my-auto px-5 text-center"
+                hidden={!!state.primaryImage || imageUploading}
+              >
                 or
               </p>
               <input
@@ -185,55 +199,63 @@ function NewOrder() {
 
                   // Error if file is over 3MB
                   if (file.size > 3_000_000) {
-                    alert("Error: Image must be less than 3 MB");
+                    alert('Error: Image must be less than 3 MB');
                     e.target.value = '';
                     setImageUploading(false);
                     return;
                   }
 
-                  const arrayBuffer = await file.arrayBuffer()
+                  const arrayBuffer = await file.arrayBuffer();
                   const cid = await postFileToIPFS(Buffer.from(arrayBuffer));
                   setImageUploading(false);
                   setShowImagePreview(true);
-                  setState((s) => ({ ...s, primaryImage: `ipfs://${cid}` }))
+                  setState((s) => ({ ...s, primaryImage: `ipfs://${cid}` }));
                 }}
               />
-              <div
-                className='my-auto'
-                hidden={!imageUploading}
-              >
-                <p className='my-auto animate-pulse'>Loading...</p>
+              <div className="my-auto" hidden={!imageUploading}>
+                <p className="my-auto animate-pulse">Loading...</p>
               </div>
-              <div 
-                className='relative h-20 ml-5'
-                hidden={imageUploading || !state.primaryImage || !showImagePreview}
+              <div
+                className="relative h-20 ml-5"
+                hidden={
+                  imageUploading || !state.primaryImage || !showImagePreview
+                }
               >
-                <img 
-                  className='h-full' 
-                  src={showImagePreview ? state.primaryImage.replace("ipfs://", "https://infura-ipfs.io/ipfs/") : ''}
-                  onLoadStart={() => (setShowImagePreview(false))}
-                  onLoad={() => (setShowImagePreview(true))} 
-                  onError={() => (setShowImagePreview(false))} 
+                <img
+                  className="h-full"
+                  src={
+                    showImagePreview
+                      ? state.primaryImage.replace(
+                          'ipfs://',
+                          'https://infura-ipfs.io/ipfs/'
+                        )
+                      : ''
+                  }
+                  onLoadStart={() => setShowImagePreview(false)}
+                  onLoad={() => setShowImagePreview(true)}
+                  onError={() => setShowImagePreview(false)}
                 ></img>
-                <button 
-                  className='absolute top-0 right-0'
+                <button
+                  className="absolute top-0 right-0"
                   onClick={() => {
-                    setState((s) => ({ ...s, primaryImage: "" }))
+                    setState((s) => ({ ...s, primaryImage: '' }));
                   }}
                 >
-                  <XIcon className="w-5 h-5 text-white bg-black rounded-full p-1 m-1"/>
+                  <XIcon className="w-5 h-5 text-white bg-black rounded-full p-1 m-1" />
                 </button>
               </div>
-              <div 
-                className='my-auto ml-5'
-                hidden={imageUploading || !state.primaryImage || showImagePreview}
+              <div
+                className="my-auto ml-5"
+                hidden={
+                  imageUploading || !state.primaryImage || showImagePreview
+                }
               >
-                <RefreshIcon className="animate-spin w-5 h-5 text-black"/>
+                <RefreshIcon className="animate-spin w-5 h-5 text-black" />
               </div>
             </label>
           </div>
-          <div className="flex mb-8">
-            <label className="flex flex-1 flex-col mr-4">
+          <div className="flex flex-col md:flex-row gap-x-4 gap-y-8">
+            <label className="flex flex-1 flex-col max-w-full md:max-w-33">
               <strong className="mb-1 text-sm">Price</strong>
               <input
                 className="border px-4 py-2 rounded"
@@ -248,53 +270,55 @@ function NewOrder() {
                 value={state.price}
               />
             </label>
-
-            <label className="flex-col">
-              <strong className="mb-1 text-sm">Token</strong>
-              <SelectSearch
-                className={(classes: string) =>
-                  cn({
-                    'w-40': true,
-                    'px-4 py-2 border rounded-l': classes === 'input',
-                    'px-4 py-2 w-full hover:bg-slate-50': classes === 'option',
-                    'border rounded-b absolute bg-white drop-shadow':
-                      classes === 'options',
-                  })
-                }
-                options={optimismList}
-                placeholder={customTokenDisabled ? 'USDC' : 'Custom Token'}
-                onChange={(opt: any) => {
-                  if (opt === 'Custom') {
-                    setCustomTokenDisabled(false);
-                    setState((s) => ({ ...s, token: '' }));
-                  } else {
-                    setState((s) => ({ ...s, token: opt }));
-                    setCustomTokenDisabled(true);
+            <div className="flex flex-1 flex-row max-w-full">
+              <label className="flex flex-col">
+                <strong className="mb-1 text-sm">Token</strong>
+                <SelectSearch
+                  className={(classes: string) =>
+                    cn({
+                      'w-40': true,
+                      'px-4 py-2 border rounded-l': classes === 'input',
+                      'px-4 py-2 w-full hover:bg-slate-50':
+                        classes === 'option',
+                      'border rounded-b absolute bg-white drop-shadow':
+                        classes === 'options',
+                    })
                   }
-                }}
-                search
-                renderOption={renderToken}
-                value={state.token}
-              />
-            </label>
+                  options={networkDropDown(activeChain?.name!)}
+                  placeholder={customTokenDisabled ? 'USDC' : 'Custom Token'}
+                  onChange={(opt: any) => {
+                    if (opt === 'Custom') {
+                      setCustomTokenDisabled(false);
+                      setState((s) => ({ ...s, token: '' }));
+                    } else {
+                      setState((s) => ({ ...s, token: opt }));
+                      setCustomTokenDisabled(true);
+                    }
+                  }}
+                  search
+                  renderOption={renderToken}
+                  value={state.token}
+                />
+              </label>
 
-            <label className="flex flex-1 flex-col">
-              <strong className="mb-1 text-sm">Token Address</strong>
-              <input
-                className="border-r border-t border-b px-4 py-2 rounded-r"
-                placeholder={DEFAULT_TOKEN}
-                disabled={customTokenDisabled}
-                onChange={(e) =>
-                  setState((s) => ({
-                    ...s,
-                    token: e.target.value,
-                  }))
-                }
-                value={state.token}
-              />
-            </label>
+              <label className="flex flex-1 flex-col">
+                <strong className="mb-1 text-sm">Token Address</strong>
+                <input
+                  className="border-r border-t border-b px-4 py-2 rounded-r"
+                  placeholder={DEFAULT_TOKEN}
+                  disabled={customTokenDisabled}
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      token: e.target.value,
+                    }))
+                  }
+                  value={state.token}
+                />
+              </label>
+            </div>
           </div>
-          <div className="flex">
+          <div className="flex flex-col md:flex-row gap-x-4 gap-y-8">
             <label className="flex flex-1 flex-col">
               <strong className="mb-1 text-sm">Seller's Stake</strong>
               <input
@@ -328,16 +352,15 @@ function NewOrder() {
             </label>
           </div>
         </div>
-        <div className="mt-8">
+        <div className="mt-12">
           <button
-            className={
-              "flex items-center px-4 py-2 rounded bg-black text-white border-black hover:opacity-50 transition-all ".concat(
-                isLoading ? 'opacity-50 animate-pulse pointer-events-none' : ''
-              )
-            }
+            className={'w-full px-4 py-3 text-lg text-center rounded bg-black text-white hover:opacity-50 transition-all'.concat(
+              isLoading ? 'opacity-50 animate-pulse pointer-events-none' : ''
+            )}
             onClick={() => createOrder().catch(console.error)}
           >
-            Publish new sell order <ArrowRightIcon className="w-4 h-4 ml-4" />
+            Publish new sell order
+            {/* <ArrowRightIcon className="w-4 h-4 ml-4" /> */}
           </button>
         </div>
       </div>

--- a/www/tailwind.config.js
+++ b/www/tailwind.config.js
@@ -13,6 +13,9 @@ module.exports = {
         gray: colors.stone,
         blue: colors.indigo,
       },
+      maxWidth: {
+        '33':'33%'
+      }
     },
   },
   plugins: [require('@tailwindcss/typography')],

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -547,9 +547,9 @@
     chai "^4.3.4"
     ethers "^5.5.4"
 
-"@eth-optimism/tokenlist@git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git":
+"@eth-optimism/tokenlist@git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git#af613ec3c5e511dbd0dc7c9cdd3d6eda311905c6":
   version "1.0.0"
-  resolved "git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git#f095e947c829d046cf0bf0fa3fd0bbdfbd743be3"
+  resolved "git+https://github.com/ethereum-optimism/ethereum-optimism.github.io.git#af613ec3c5e511dbd0dc7c9cdd3d6eda311905c6"
   dependencies:
     "@actions/core" "^1.4.0"
     "@changesets/cli" "^2.16.0"
@@ -6531,6 +6531,10 @@ pngjs@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
   integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
+"polygon-token-list@git+https://github.com/maticnetwork/polygon-token-list.git#ce24aa9288aeb30db2dc788213706424bd34c540":
+  version "1.0.0"
+  resolved "git+https://github.com/maticnetwork/polygon-token-list.git#ce24aa9288aeb30db2dc788213706424bd34c540"
 
 postcss-js@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Added changing token dropdowns, so addresses will reflect whatever network the user is on. Currently have Optimism, Rinkeby and Polygon, although I'm not able to test Optimism and Polygon because of the network limitations for dev, can I maybe get some help changing this?
- changed sell page to more closely match figma, and have more size flexibility
<img width="785" alt="Screen Shot 2022-05-27 at 3 40 16 AM" src="https://user-images.githubusercontent.com/46611122/170686349-b292aa96-e322-4505-84e7-4c072faba167.png">
<img width="663" alt="Screen Shot 2022-05-27 at 3 40 42 AM" src="https://user-images.githubusercontent.com/46611122/170686352-5373cf00-0f44-4948-a580-b0a79d62c6be.png">
