### PR TITLE
Abstract out keystore 

### DIFF
--- a/www/components/KeystoreModal.tsx
+++ b/www/components/KeystoreModal.tsx
@@ -3,7 +3,7 @@ import { NextRouter } from 'next/router';
 import { FadeIn } from './FadeIn';
 
 export function KeystoreModal(props: {
-  login: () => Promise<void>;
+  login: () => Promise<string>;
   router: NextRouter;
 }) {
   return (

--- a/www/components/SubmitOfferButton.tsx
+++ b/www/components/SubmitOfferButton.tsx
@@ -2,7 +2,6 @@ import { RefreshIcon } from '@heroicons/react/solid';
 import { BigNumber } from 'ethers';
 import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useState } from 'react';
-import nacl from 'tweetnacl';
 import { postJSONToIPFS } from '../lib/ipfs';
 import { encryptMessage, formatMessageForUpload } from '../lib/keystoreLib';
 import { formatTokenAmount, useTokenMethods } from '../lib/tokens';
@@ -82,9 +81,12 @@ export function SubmitOfferButton(props: {
         receiverPublicEncryptionKey: props.order.encryptionPublicKey,
         secretData: JSON.stringify(props.offerData),
         senderPrivatekey: buyersEncryptionKeypair?.secretKey,
-      })
+      });
 
-      const data = formatMessageForUpload(msg, buyersEncryptionKeypair.publicKey);
+      const data = formatMessageForUpload(
+        msg,
+        buyersEncryptionKeypair.publicKey
+      );
       return await postJSONToIPFS(data);
     } catch (error) {
       setLoadingMessage('');

--- a/www/lib/keystore.tsx
+++ b/www/lib/keystore.tsx
@@ -1,10 +1,7 @@
 import { useAccount, useSigner } from 'wagmi';
-import { ReactNode } from 'react';
 import useSWR from 'swr';
 import { useLocalStorage } from './useLocalStorage';
-import { ConnectWalletLayout } from '../components/Layout';
-import { useRouter } from 'next/router';
-import { KeystoreModal } from '../components/KeystoreModal';
+import { keystoreConstructor, keystoreLogin } from './keystoreLib';
 
 export function useKeystoreLogin() {
   const signer = useSigner();
@@ -14,163 +11,26 @@ export function useKeystoreLogin() {
     ''
   );
 
-  function toToken(address: string, sig: string) {
-    if (!address || !sig) return null;
-    return Buffer.from(`${address}:${sig}`).toString('base64');
-  }
+  const keystore = keystoreLogin({
+    signer: signer.data!,
+    address: account.data?.address,
+    setSig,
+  });
 
   // Checks in the background if we're logged in.
-  const loginCheck = useSWR(
-    ['https://kv.rwtp.workers.dev/whoami', account.data?.address, sig],
-    async (url: string, address: string, sig: string) => {
-      if (!address || !sig) return false;
-      const token = toToken(address, sig);
-      if (!token) return false;
-
-      const res = await fetch(url, {
-        headers: {
-          Authorization: `Basic ${token}`,
-        },
-      });
-
-      return res.status === 200;
-    }
-  );
-
-  async function login() {
-    if (!signer.data) {
-      throw new Error(
-        "Can't attempt to login to the keystore if the user hasn't connected their wallet."
-      );
-    }
-
-    const result = await fetch(
-      'https://kv.rwtp.workers.dev/challenge/' +
-        (await signer.data?.getAddress()),
-      {
-        method: 'POST',
-      }
-    );
-    const challenge = await result.text();
-    const s = await signer.data.signMessage(challenge);
-    setSig(s);
-  }
+  const loginCheck = useSWR([account.data?.address, sig], keystore.loginCheck);
 
   return {
-    login,
+    login: keystore.login,
     isLoading: loginCheck.data === undefined,
     isLoggedIn: !!loginCheck.data,
-    token: toToken(account.data?.address || '', sig),
+    token: keystore.toToken(account.data?.address || '', sig),
   };
 }
-
 /**
  * A little hook to use the keystore
  */
 export function useKeystore() {
   const loginDetails = useKeystoreLogin();
-
-  async function put(key: string, value: string) {
-    if (!loginDetails.isLoggedIn) {
-      throw new Error("Can't put while not logged in.");
-    }
-
-    const res = await fetch('https://kv.rwtp.workers.dev/put/' + key, {
-      method: 'POST',
-      headers: {
-        Authorization: `Basic ${loginDetails.token}`,
-      },
-      body: value,
-    });
-
-    if (res.status !== 200) {
-      throw new Error(await res.text());
-    }
-  }
-
-  async function get(key: string): Promise<string> {
-    if (!loginDetails.isLoggedIn) {
-      throw new Error("Can't get while not logged in.");
-    }
-
-    const res = await fetch('https://kv.rwtp.workers.dev/get/' + key, {
-      method: 'GET',
-      headers: {
-        Authorization: `Basic ${loginDetails.token}`,
-      },
-    });
-
-    if (res.status !== 200) {
-      throw new Error(await res.text());
-    }
-
-    return await res.text();
-  }
-
-  return {
-    login: loginDetails.login,
-    isLoggedIn: loginDetails.isLoggedIn,
-    isLoading: loginDetails.isLoading,
-    put,
-    get,
-  };
-}
-
-export function useKeystoreGet(key: string) {
-  const login = useKeystoreLogin();
-
-  // Checks in the background if we're logged in.
-  return useSWR(
-    ['https://kv.rwtp.workers.dev/get' + key, login.token],
-    async (url: string, token: string, _key: string) => {
-      if (!token) return null;
-
-      const res = await fetch(url, {
-        headers: {
-          Authorization: `Basic ${token}`,
-        },
-      });
-
-      if (res.status !== 200) {
-        throw new Error(await res.text());
-      }
-
-      return await res.text();
-    }
-  );
-}
-
-// Wrap anything needing the keystore in this hook, and it'll show
-// a little screen asking someone to approve the login
-export function RequiresKeystore(props: { children: ReactNode }) {
-  const login = useKeystore();
-  const router = useRouter();
-  const account = useAccount();
-
-  // Loading
-  if (login.isLoading) {
-    return (
-      <ConnectWalletLayout>
-        <div></div>
-      </ConnectWalletLayout>
-    );
-  }
-
-  if (login.isLoggedIn) {
-    return <>{props.children}</>;
-  }
-
-  if (!account.data?.address) {
-    return (
-      <ConnectWalletLayout>
-        <div></div>
-      </ConnectWalletLayout>
-    );
-  }
-
-  return (
-    <ConnectWalletLayout>
-      <KeystoreModal router={router} login={login.login} />
-    </ConnectWalletLayout>
-  );
+  return keystoreConstructor(loginDetails);
 }

--- a/www/lib/keystoreLib.ts
+++ b/www/lib/keystoreLib.ts
@@ -127,3 +127,43 @@ export function encryptionKeypairExpanded(encryptionKeypair: nacl.BoxKeyPair) {
     secretKeyAsHex: Buffer.from(encryptionKeypair.secretKey).toString('hex'),
   };
 }
+
+interface EncryptionMessage {
+  receiverPublicEncryptionKey: string;
+  secretData: string;
+  senderPrivatekey: Uint8Array;
+}
+
+interface EncryptedMessage {
+  nonce: Uint8Array,
+  // Message that is encrypted
+  encrypted: Uint8Array
+}
+
+export function encryptMessage(msg: EncryptionMessage): EncryptedMessage {
+  const secretDataUTF8 = Buffer.from(msg.secretData, 'utf-8');
+  const nonce = nacl.randomBytes(24);
+  const sellersPublicEncryptionKey = Uint8Array.from(
+    Buffer.from(msg.receiverPublicEncryptionKey, 'hex')
+  );
+  const encrypted = nacl.box(
+    secretDataUTF8,
+    nonce,
+    sellersPublicEncryptionKey,
+    msg.senderPrivatekey
+  );
+  return {
+    nonce,
+    encrypted
+  };
+}
+
+export function formatMessageForUpload(msg: EncryptedMessage, publicKey: Uint8Array) {
+  return {
+    publicKey: Buffer.from(publicKey).toString(
+      'hex'
+    ),
+    nonce: Buffer.from(msg.nonce).toString('hex'),
+    message: Buffer.from(msg.encrypted).toString('hex'),
+  };
+}

--- a/www/lib/keystoreLib.ts
+++ b/www/lib/keystoreLib.ts
@@ -1,0 +1,129 @@
+import { Signer } from 'ethers';
+import * as nacl from 'tweetnacl';
+
+const ENCRYPTION_KEY = 'encryptionKey:0';
+
+interface LoginDetails {
+  login: () => Promise<string>;
+  isLoading: boolean;
+  isLoggedIn: boolean;
+  token: string | null;
+}
+
+interface WalletMockImpl {
+  signer: Signer;
+  address: string | undefined;
+  setSig: (sig: string) => void;
+}
+
+export function keystoreLogin(walletMock: WalletMockImpl) {
+  function toToken(address: string, sig: string): string | null {
+    if (!address || !sig) return null;
+    return Buffer.from(`${address}:${sig}`).toString('base64');
+  }
+
+  async function loginCheck(address: string, sig: string): Promise<boolean> {
+    if (!address || !sig) return false;
+    const token = toToken(address, sig);
+    if (!token) return false;
+
+    const res = await fetch('https://kv.rwtp.workers.dev/whoami', {
+      headers: {
+        Authorization: `Basic ${token}`,
+      },
+    });
+
+    return res.status === 200;
+  }
+
+  async function login(): Promise<string> {
+    const result = await fetch(
+      'https://kv.rwtp.workers.dev/challenge/' +
+        (await walletMock.signer.getAddress()),
+      {
+        method: 'POST',
+      }
+    );
+    const challenge = await result.text();
+    const sig = await walletMock.signer.signMessage(challenge);
+    walletMock.setSig(sig);
+    return sig;
+  }
+
+  return {
+    login,
+    toToken,
+    loginCheck,
+  };
+}
+
+export function keystoreConstructor(loginDetails: LoginDetails) {
+  async function put(key: string, value: string) {
+    if (!loginDetails.isLoggedIn) {
+      throw new Error("Can't put while not logged in.");
+    }
+
+    const res = await fetch('https://kv.rwtp.workers.dev/put/' + key, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${loginDetails.token}`,
+      },
+      body: value,
+    });
+
+    if (res.status !== 200) {
+      throw new Error(await res.text());
+    }
+  }
+
+  async function get(key: string): Promise<string> {
+    if (!loginDetails.isLoggedIn) {
+      throw new Error("Can't get while not logged in.");
+    }
+
+    const res = await fetch('https://kv.rwtp.workers.dev/get/' + key, {
+      method: 'GET',
+      headers: {
+        Authorization: `Basic ${loginDetails.token}`,
+      },
+    });
+
+    if (res.status !== 200) {
+      throw new Error(await res.text());
+    }
+
+    return await res.text();
+  }
+
+  return {
+    login: loginDetails.login,
+    isLoggedIn: loginDetails.isLoggedIn,
+    isLoading: loginDetails.isLoading,
+    put,
+    get,
+  };
+}
+
+export async function getEncryptionKeyPair(keystore: any) {
+  const result = await keystore.get(ENCRYPTION_KEY);
+  if (!result) {
+    let keypair = nacl.box.keyPair();
+    let secretKey = Buffer.from(keypair.secretKey).toString('hex');
+    await keystore.put(ENCRYPTION_KEY, secretKey);
+    return keypair;
+  }
+
+  const secretKey = Uint8Array.from(Buffer.from(result, 'hex'));
+  const keypair = nacl.box.keyPair.fromSecretKey(secretKey);
+  return keypair;
+}
+
+export function useEncryptionKeypairExpanded(
+  encryptionKeypair: nacl.BoxKeyPair
+) {
+  return {
+    ...encryptionKeypair,
+    publicKeyAsHex: Buffer.from(encryptionKeypair.publicKey).toString('hex'),
+    secretKeyAsHex: Buffer.from(encryptionKeypair.secretKey).toString('hex'),
+  };
+}

--- a/www/lib/keystoreLib.ts
+++ b/www/lib/keystoreLib.ts
@@ -135,9 +135,9 @@ interface EncryptionMessage {
 }
 
 interface EncryptedMessage {
-  nonce: Uint8Array,
+  nonce: Uint8Array;
   // Message that is encrypted
-  encrypted: Uint8Array
+  encrypted: Uint8Array;
 }
 
 export function encryptMessage(msg: EncryptionMessage): EncryptedMessage {
@@ -154,15 +154,16 @@ export function encryptMessage(msg: EncryptionMessage): EncryptedMessage {
   );
   return {
     nonce,
-    encrypted
+    encrypted,
   };
 }
 
-export function formatMessageForUpload(msg: EncryptedMessage, publicKey: Uint8Array) {
+export function formatMessageForUpload(
+  msg: EncryptedMessage,
+  publicKey: Uint8Array
+) {
   return {
-    publicKey: Buffer.from(publicKey).toString(
-      'hex'
-    ),
+    publicKey: Buffer.from(publicKey).toString('hex'),
     nonce: Buffer.from(msg.nonce).toString('hex'),
     message: Buffer.from(msg.encrypted).toString('hex'),
   };

--- a/www/lib/keystoreLib.ts
+++ b/www/lib/keystoreLib.ts
@@ -13,7 +13,7 @@ interface LoginDetails {
 interface WalletMockImpl {
   signer: Signer;
   address: string | undefined;
-  setSig: (sig: string) => void;
+  setSig: (_sig: string) => void;
 }
 
 export function keystoreLogin(walletMock: WalletMockImpl) {
@@ -96,7 +96,9 @@ export function keystoreConstructor(loginDetails: LoginDetails) {
   }
 
   return {
-    login: loginDetails.login,
+    login: async function () {
+      await loginDetails.login;
+    },
     isLoggedIn: loginDetails.isLoggedIn,
     isLoading: loginDetails.isLoading,
     put,
@@ -118,9 +120,7 @@ export async function getEncryptionKeyPair(keystore: any) {
   return keypair;
 }
 
-export function useEncryptionKeypairExpanded(
-  encryptionKeypair: nacl.BoxKeyPair
-) {
+export function encryptionKeypairExpanded(encryptionKeypair: nacl.BoxKeyPair) {
   return {
     ...encryptionKeypair,
     publicKeyAsHex: Buffer.from(encryptionKeypair.publicKey).toString('hex'),

--- a/www/lib/useEncryptionKey.ts
+++ b/www/lib/useEncryptionKey.ts
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as nacl from 'tweetnacl';
 import { useKeystore } from './keystore';
-import {
-  getEncryptionKeyPair,
-  useEncryptionKeypairExpanded,
-} from './keystoreLib';
+import { getEncryptionKeyPair, encryptionKeypairExpanded } from './keystoreLib';
 
 /**
  * Grab an encryption key from the keystore
@@ -24,7 +21,7 @@ export function useEncryptionKeypair() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (encryptionKeypair) {
-    return useEncryptionKeypairExpanded(encryptionKeypair);
+    return encryptionKeypairExpanded(encryptionKeypair);
   } else {
     return null;
   }

--- a/www/pages/api/uploadJson.ts
+++ b/www/pages/api/uploadJson.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { CID, create } from 'ipfs-http-client';
+import { create } from 'ipfs-http-client';
 import { AbortController } from 'node-abort-controller';
 
 global.AbortController = AbortController;

--- a/www/pages/api/uploadJson.ts
+++ b/www/pages/api/uploadJson.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { create } from 'ipfs-http-client';
+import { CID, create } from 'ipfs-http-client';
 import { AbortController } from 'node-abort-controller';
 
 global.AbortController = AbortController;
@@ -12,12 +12,8 @@ type Body = {
   data: string;
 };
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Response>
-) {
-  const body = req.body as Body;
-
+export async function uploadJson(body: any): Promise<string> {
+  console.log('body:', body);
   const projectId = process.env.INFURA_IPFS_PROJECT_ID;
   const projectSecret = process.env.INFURA_IPFS_PROJECT_SECRET;
   const auth =
@@ -50,6 +46,13 @@ export default async function handler(
   });
   const graphIpfsResult = await graphIpfs.add(input);
   console.log('uploaded to the graph ipfs node {}', graphIpfsResult);
+  return addResult.cid.toString();
+}
 
-  res.status(200).json({ cid: addResult.cid.toString() });
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Response>
+) {
+  const body = req.body as Body;
+  res.status(200).json({ cid: await uploadJson(body) });
 }


### PR DESCRIPTION
Completely abstracted out all of the logic for keystores and separated it from UI components like useEffect

Tested abstract version on branch `exmaple-with-active` at commit : `ff0b2d69a4f5666980fa5af68e046359f3838c25`


# Ran an end 2 end test

![image](https://user-images.githubusercontent.com/26822232/172539624-2e489907-68fb-43ee-ae17-11a09f19ed69.png)

# Ran a second e2e test
![image](https://user-images.githubusercontent.com/26822232/172600380-e4886375-4562-4b43-a9e2-c6512236ec77.png)
